### PR TITLE
feat:  구글 OIDC를 이용한 소셜 회원가입 및 로그인 api 구현 

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+# PR
+
+## PR 요약
+summary
+
+## 변경된 점
+changes
+
+## 이슈 번호
+issue number

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+### 8HERTZ ###
+**/.env
+
 ### STS ###
 .apt_generated
 .classpath

--- a/build.gradle
+++ b/build.gradle
@@ -23,11 +23,18 @@ repositories {
 	mavenCentral()
 }
 
+ext {
+	set('springCloudVersion', "2023.0.3")
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 	// Spring Boot Actuator
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
@@ -36,16 +43,26 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.0.4'
 
+	// OpenFeign
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
 	// jwt
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
 	compileOnly 'org.projectlombok:lombok'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,19 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	// Spring Boot Actuator
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+	// swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.0.4'
+
+	// jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.4.2'
-	id 'io.spring.dependency-management' version '1.1.7'
+	id 'org.springframework.boot' version '3.3.2'
+	id 'io.spring.dependency-management' version '1.1.6'
 }
 
 group = 'com.haertz'
@@ -40,8 +40,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
 	// swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.0.4'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.3.0'
 
 	// OpenFeign
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'be'
+rootProject.name = 'BE'

--- a/src/main/java/com/haertz/be/BeApplication.java
+++ b/src/main/java/com/haertz/be/BeApplication.java
@@ -2,7 +2,14 @@ package com.haertz.be;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+
+@ConfigurationPropertiesScan
+@EnableCaching
+@EnableFeignClients
 @SpringBootApplication
 public class BeApplication {
 

--- a/src/main/java/com/haertz/be/auth/adaptor/RefreshTokenRedisAdaptor.java
+++ b/src/main/java/com/haertz/be/auth/adaptor/RefreshTokenRedisAdaptor.java
@@ -1,0 +1,29 @@
+package com.haertz.be.auth.adaptor;
+
+import com.haertz.be.auth.entity.RefreshToken;
+import com.haertz.be.auth.exception.UserErrorCode;
+import com.haertz.be.auth.repository.RefreshTokenRedisDao;
+import com.haertz.be.common.annotation.Adaptor;
+import com.haertz.be.common.exception.base.BaseException;
+import lombok.RequiredArgsConstructor;
+
+
+@Adaptor
+@RequiredArgsConstructor
+// RefreshTokenRedisDao를 사용하여 데이터 저장 및 조회
+public class RefreshTokenRedisAdaptor {
+    private final RefreshTokenRedisDao refreshTokenRedisDao;
+
+    public void save(Long id, RefreshToken refreshToken, Long exp) {
+        refreshTokenRedisDao.saveWithExpiration(refreshTokenRedisDao.generateKeyFromId(id), refreshToken, exp);
+    }
+
+    public RefreshToken findById(Long id) {
+        return refreshTokenRedisDao.findById(id)
+                .orElseThrow(() -> new BaseException(UserErrorCode.EXPIRED_REFRESH_TOKEN));
+    }
+
+    public void deleteByKey(String key) {
+        refreshTokenRedisDao.deleteByKey(key);
+    }
+}

--- a/src/main/java/com/haertz/be/auth/adaptor/TokenBlacklistRedisAdaptor.java
+++ b/src/main/java/com/haertz/be/auth/adaptor/TokenBlacklistRedisAdaptor.java
@@ -1,0 +1,21 @@
+package com.haertz.be.auth.adaptor;
+
+import com.haertz.be.auth.repository.TokenBlacklistRedisDao;
+import com.haertz.be.common.annotation.Adaptor;
+import lombok.RequiredArgsConstructor;
+
+@Adaptor
+@RequiredArgsConstructor
+// 액세스 토큰 블랙리스트 처리
+public class TokenBlacklistRedisAdaptor {
+    private final TokenBlacklistRedisDao tokenBlacklistRedisDao;
+
+    public void save(String accessToken, Long exp) {
+        tokenBlacklistRedisDao.saveWithExpiration(tokenBlacklistRedisDao.generateKey(accessToken),true, exp);
+    }
+
+    public boolean hasKey(String accessToken){
+        return tokenBlacklistRedisDao.hasKey(accessToken);
+    }
+
+}

--- a/src/main/java/com/haertz/be/auth/adaptor/UserAdaptor.java
+++ b/src/main/java/com/haertz/be/auth/adaptor/UserAdaptor.java
@@ -1,0 +1,37 @@
+package com.haertz.be.auth.adaptor;
+
+import com.haertz.be.auth.entity.User;
+import com.haertz.be.auth.exception.UserErrorCode;
+import com.haertz.be.auth.repository.UserRepository;
+import com.haertz.be.common.annotation.Adaptor;
+import com.haertz.be.common.exception.base.BaseException;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Adaptor
+@RequiredArgsConstructor
+public class UserAdaptor {
+    private final UserRepository userRepository;
+
+    public User findById(Long id) {
+        return userRepository.findById(id)
+                .orElseThrow(() -> new BaseException(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    public User findByEmail(String email) {
+        return userRepository.findByAuthInfoEmail(email)
+                .orElseThrow(() -> new BaseException(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    public Boolean existsByEmail(String email) {
+        return userRepository.existsByAuthInfoEmail(email);
+    }
+
+    public User save(User user) {
+        return userRepository.save(user);
+    }
+
+
+}

--- a/src/main/java/com/haertz/be/auth/controller/AuthController.java
+++ b/src/main/java/com/haertz/be/auth/controller/AuthController.java
@@ -3,10 +3,7 @@ package com.haertz.be.auth.controller;
 
 import com.haertz.be.auth.dto.response.AccountTokenDto;
 import com.haertz.be.auth.dto.response.IdTokenDto;
-import com.haertz.be.auth.usecase.LoginUseCase;
-import com.haertz.be.auth.usecase.LogoutUseCase;
-import com.haertz.be.auth.usecase.RequestTokenUseCase;
-import com.haertz.be.auth.usecase.SignUpUseCase;
+import com.haertz.be.auth.usecase.*;
 import com.haertz.be.common.response.SuccessResponse;
 import com.haertz.be.common.utils.TokenUtils;
 import io.swagger.v3.oas.annotations.Operation;
@@ -24,7 +21,8 @@ public class AuthController {
     private final RequestTokenUseCase requestTokenUseCase;
     private final SignUpUseCase signUpUseCase;
     private final LoginUseCase loginUseCase;
-    private  final LogoutUseCase logoutUseCase;
+    private final LogoutUseCase logoutUseCase;
+    private final RefreshTokenUseCase refreshTokenUseCase;
 
     @Operation(summary = "구글 id token을 발급받습니다.")
     @GetMapping("/idtoken")
@@ -49,6 +47,7 @@ public class AuthController {
         AccountTokenDto accountTokenDto = loginUseCase.execute(loginType, TokenUtils.resolveToken(request), response);
         return SuccessResponse.of(accountTokenDto);
     }
+
     @Operation(summary = "로그아웃 합니다. *access token 이용*")
     @PostMapping("/logout")
     public SuccessResponse<Void> logout(HttpServletRequest request, HttpServletResponse response){
@@ -56,7 +55,11 @@ public class AuthController {
         return SuccessResponse.empty();
     }
 
-
-
+    @Operation(summary = "refresh token으로 access token을 재발급합니다. *refresh token 이용*")
+    @PostMapping("/refresh")
+    public SuccessResponse<Object> refreshToken(@CookieValue(value = "refreshToken") String refreshToken, HttpServletResponse response) {
+        AccountTokenDto accountTokenDto = refreshTokenUseCase.execute(refreshToken, response);
+        return SuccessResponse.of(accountTokenDto);
+    }
 
 }

--- a/src/main/java/com/haertz/be/auth/controller/AuthController.java
+++ b/src/main/java/com/haertz/be/auth/controller/AuthController.java
@@ -1,16 +1,17 @@
 package com.haertz.be.auth.controller;
 
 
+import com.haertz.be.auth.dto.response.AccountTokenDto;
 import com.haertz.be.auth.dto.response.IdTokenDto;
 import com.haertz.be.auth.usecase.*;
 import com.haertz.be.common.response.SuccessResponse;
+import com.haertz.be.common.utils.TokenUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "사용자 인증 API", description = "사용자 인증 관련 API 입니다.")
 public class AuthController {
     private final RequestTokenUseCase requestTokenUseCase;
+    private final SignUpUseCase signUpUseCase;
 
     @Operation(summary = "구글 id token을 발급받습니다.")
     @GetMapping("/idtoken")
@@ -26,4 +28,13 @@ public class AuthController {
         IdTokenDto idTokenDto = requestTokenUseCase.execute(loginType, code);
         return SuccessResponse.of(idTokenDto);
     }
+
+    @Operation(summary = "구글 id token으로 회원가입합니다.")
+    @PostMapping("/signup")
+    public SuccessResponse<Object> signUp(HttpServletRequest request, HttpServletResponse response,
+                                          @RequestParam(value = "logintype", defaultValue = "google") String loginType) {
+        AccountTokenDto accountTokenDto = signUpUseCase.execute(loginType, TokenUtils.resolveToken(request), response);
+        return SuccessResponse.of(accountTokenDto);
+    }
+
 }

--- a/src/main/java/com/haertz/be/auth/controller/AuthController.java
+++ b/src/main/java/com/haertz/be/auth/controller/AuthController.java
@@ -3,7 +3,9 @@ package com.haertz.be.auth.controller;
 
 import com.haertz.be.auth.dto.response.AccountTokenDto;
 import com.haertz.be.auth.dto.response.IdTokenDto;
-import com.haertz.be.auth.usecase.*;
+import com.haertz.be.auth.usecase.LoginUseCase;
+import com.haertz.be.auth.usecase.RequestTokenUseCase;
+import com.haertz.be.auth.usecase.SignUpUseCase;
 import com.haertz.be.common.response.SuccessResponse;
 import com.haertz.be.common.utils.TokenUtils;
 import io.swagger.v3.oas.annotations.Operation;
@@ -20,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
     private final RequestTokenUseCase requestTokenUseCase;
     private final SignUpUseCase signUpUseCase;
+    private final LoginUseCase loginUseCase;
 
     @Operation(summary = "구글 id token을 발급받습니다.")
     @GetMapping("/idtoken")
@@ -36,5 +39,14 @@ public class AuthController {
         AccountTokenDto accountTokenDto = signUpUseCase.execute(loginType, TokenUtils.resolveToken(request), response);
         return SuccessResponse.of(accountTokenDto);
     }
+
+    @Operation(summary = "구글 id token으로 로그인합니다.")
+    @PostMapping("/login")
+    public SuccessResponse<Object> login(
+            HttpServletRequest request, HttpServletResponse response, @RequestParam(value = "logintype", defaultValue = "google") String loginType) {
+        AccountTokenDto accountTokenDto = loginUseCase.execute(loginType, TokenUtils.resolveToken(request), response);
+        return SuccessResponse.of(accountTokenDto);
+    }
+
 
 }

--- a/src/main/java/com/haertz/be/auth/controller/AuthController.java
+++ b/src/main/java/com/haertz/be/auth/controller/AuthController.java
@@ -1,0 +1,29 @@
+package com.haertz.be.auth.controller;
+
+
+import com.haertz.be.auth.dto.response.IdTokenDto;
+import com.haertz.be.auth.usecase.*;
+import com.haertz.be.common.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+@Tag(name = "사용자 인증 API", description = "사용자 인증 관련 API 입니다.")
+public class AuthController {
+    private final RequestTokenUseCase requestTokenUseCase;
+
+    @Operation(summary = "구글 id token을 발급받습니다.")
+    @GetMapping("/idtoken")
+    public SuccessResponse<Object> getIdToken(@RequestParam("code") String code,
+                                              @RequestParam(value = "logintype", defaultValue = "google") String loginType) {
+        IdTokenDto idTokenDto = requestTokenUseCase.execute(loginType, code);
+        return SuccessResponse.of(idTokenDto);
+    }
+}

--- a/src/main/java/com/haertz/be/auth/controller/AuthController.java
+++ b/src/main/java/com/haertz/be/auth/controller/AuthController.java
@@ -4,6 +4,7 @@ package com.haertz.be.auth.controller;
 import com.haertz.be.auth.dto.response.AccountTokenDto;
 import com.haertz.be.auth.dto.response.IdTokenDto;
 import com.haertz.be.auth.usecase.LoginUseCase;
+import com.haertz.be.auth.usecase.LogoutUseCase;
 import com.haertz.be.auth.usecase.RequestTokenUseCase;
 import com.haertz.be.auth.usecase.SignUpUseCase;
 import com.haertz.be.common.response.SuccessResponse;
@@ -23,6 +24,7 @@ public class AuthController {
     private final RequestTokenUseCase requestTokenUseCase;
     private final SignUpUseCase signUpUseCase;
     private final LoginUseCase loginUseCase;
+    private  final LogoutUseCase logoutUseCase;
 
     @Operation(summary = "구글 id token을 발급받습니다.")
     @GetMapping("/idtoken")
@@ -47,6 +49,14 @@ public class AuthController {
         AccountTokenDto accountTokenDto = loginUseCase.execute(loginType, TokenUtils.resolveToken(request), response);
         return SuccessResponse.of(accountTokenDto);
     }
+    @Operation(summary = "로그아웃 합니다. *access token 이용*")
+    @PostMapping("/logout")
+    public SuccessResponse<Void> logout(HttpServletRequest request, HttpServletResponse response){
+        logoutUseCase.execute(TokenUtils.resolveToken(request), response);
+        return SuccessResponse.empty();
+    }
+
+
 
 
 }

--- a/src/main/java/com/haertz/be/auth/dto/response/AccountTokenDto.java
+++ b/src/main/java/com/haertz/be/auth/dto/response/AccountTokenDto.java
@@ -1,0 +1,31 @@
+package com.haertz.be.auth.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Data;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+@Data
+@Builder
+public class AccountTokenDto {
+    @JsonInclude(NON_NULL)
+    private String accessToken;
+
+    private Boolean isRegistered;
+
+    public static AccountTokenDto of(String accessToken) {
+        return AccountTokenDto.builder()
+                .accessToken(accessToken)
+                .isRegistered(true)
+                .build();
+    }
+
+    public static AccountTokenDto notRegistered() {
+        return AccountTokenDto.builder()
+                .accessToken(null)
+                .isRegistered(false)
+                .build();
+    }
+
+}

--- a/src/main/java/com/haertz/be/auth/dto/response/IdTokenDto.java
+++ b/src/main/java/com/haertz/be/auth/dto/response/IdTokenDto.java
@@ -1,0 +1,16 @@
+package com.haertz.be.auth.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class IdTokenDto {
+    private String idToken;
+
+    public static IdTokenDto of(String idToken){
+        return IdTokenDto.builder()
+                .idToken(idToken)
+                .build();
+    }
+}

--- a/src/main/java/com/haertz/be/auth/dto/response/UserProfileDto.java
+++ b/src/main/java/com/haertz/be/auth/dto/response/UserProfileDto.java
@@ -1,0 +1,7 @@
+package com.haertz.be.auth.dto.response;
+
+public record UserProfileDto(String name, String email){
+    public static UserProfileDto from(String name, String email){
+        return new UserProfileDto(name, email);
+    }
+}

--- a/src/main/java/com/haertz/be/auth/entity/AccountStatus.java
+++ b/src/main/java/com/haertz/be/auth/entity/AccountStatus.java
@@ -1,0 +1,13 @@
+package com.haertz.be.auth.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum AccountStatus {
+    MEMBER("MEMBER"),
+    DELETE("DELETED");
+
+    private final String value;
+}

--- a/src/main/java/com/haertz/be/auth/entity/AuthInfo.java
+++ b/src/main/java/com/haertz/be/auth/entity/AuthInfo.java
@@ -1,0 +1,44 @@
+package com.haertz.be.auth.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import static com.haertz.be.auth.entity.Role.USER;
+@Builder
+@Getter
+@Embeddable
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AuthInfo {
+
+    @NotNull
+    @Column
+    @Enumerated(EnumType.STRING)
+    private LoginType loginType; //로그인 타입
+
+    @NotNull
+    @Column
+    private String email; //이메일
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private AccountStatus accountStatus; //계정 상태
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private Role role; //역할
+
+    public static AuthInfo authInfoForSignUp(LoginType loginType, String email) {
+        return AuthInfo.builder()
+                .loginType(loginType)
+                .email(email)
+                .accountStatus(AccountStatus.MEMBER)
+                .role(USER)
+                .build();
+    }
+
+}

--- a/src/main/java/com/haertz/be/auth/entity/LoginType.java
+++ b/src/main/java/com/haertz/be/auth/entity/LoginType.java
@@ -1,0 +1,23 @@
+package com.haertz.be.auth.entity;
+
+import com.haertz.be.auth.exception.UserErrorCode;
+import com.haertz.be.common.exception.base.BaseException;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum LoginType {
+    GOOGLE("google");
+
+    private final String value;
+
+    public static LoginType fromValue(String value){
+        for (LoginType type : LoginType.values()){
+            if (type.value.equalsIgnoreCase(value)){
+                return type;
+            }
+        }
+        throw new BaseException(UserErrorCode.NOT_SUPPORTED_LOGINTYPE_ERROR);
+    }
+}

--- a/src/main/java/com/haertz/be/auth/entity/RefreshToken.java
+++ b/src/main/java/com/haertz/be/auth/entity/RefreshToken.java
@@ -1,0 +1,15 @@
+package com.haertz.be.auth.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class RefreshToken {
+    private Long userId;
+    private String token;
+}

--- a/src/main/java/com/haertz/be/auth/entity/Role.java
+++ b/src/main/java/com/haertz/be/auth/entity/Role.java
@@ -1,0 +1,12 @@
+package com.haertz.be.auth.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum Role {
+    USER("USER");
+
+    private final String value;
+}

--- a/src/main/java/com/haertz/be/auth/entity/User.java
+++ b/src/main/java/com/haertz/be/auth/entity/User.java
@@ -1,0 +1,27 @@
+package com.haertz.be.auth.entity;
+
+import com.haertz.be.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "user", uniqueConstraints = @UniqueConstraint(columnNames = {"login_type", "email"}))
+public class User extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long userId;
+
+    private String userName;
+
+    @Embedded
+    @NotNull
+    private AuthInfo authInfo;
+
+}

--- a/src/main/java/com/haertz/be/auth/exception/UserErrorCode.java
+++ b/src/main/java/com/haertz/be/auth/exception/UserErrorCode.java
@@ -1,0 +1,19 @@
+package com.haertz.be.auth.exception;
+
+import com.haertz.be.common.exception.base.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorCode implements BaseErrorCode {
+    NOT_SUPPORTED_LOGINTYPE_ERROR(400, "USER_400","지원하지 않는 로그인 타입입니다"),
+    EMAIL_ALREADY_REGISTERED(409,"USER_409","이미 존재하는 이메일 주소입니다."),
+    EXPIRED_REFRESH_TOKEN(401,"REFRESH_TOKEN_401","refresh_token이 만료되었습니다."),
+    USER_NOT_FOUND(404, "USER_404","유저를 찾을 수 없습니다.");
+
+    private final int httpStatus;
+    private final String code;
+    private final String message;
+
+}

--- a/src/main/java/com/haertz/be/auth/repository/RefreshTokenRedisDao.java
+++ b/src/main/java/com/haertz/be/auth/repository/RefreshTokenRedisDao.java
@@ -1,0 +1,21 @@
+package com.haertz.be.auth.repository;
+
+import com.haertz.be.auth.entity.RefreshToken;
+import com.haertz.be.common.annotation.RedisRepository;
+import com.haertz.be.common.redis.BaseRedisRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import static com.haertz.be.common.constant.StaticValue.REFRESH_TOKEN_PREFIX;
+
+
+@RedisRepository
+public class RefreshTokenRedisDao extends BaseRedisRepository<RefreshToken> {
+
+    @Autowired
+    public RefreshTokenRedisDao(RedisTemplate<String, RefreshToken> redisTemplate) {
+        this.prefix = REFRESH_TOKEN_PREFIX; // 리프레시 토큰의 접두사 설정
+        this.redisTemplate = redisTemplate;
+    }
+
+}

--- a/src/main/java/com/haertz/be/auth/repository/TokenBlacklistRedisDao.java
+++ b/src/main/java/com/haertz/be/auth/repository/TokenBlacklistRedisDao.java
@@ -1,0 +1,19 @@
+package com.haertz.be.auth.repository;
+
+import com.haertz.be.common.annotation.RedisRepository;
+import com.haertz.be.common.redis.BaseRedisRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import static com.haertz.be.common.constant.StaticValue.BLACKlIST_PREFIX;
+
+
+@RedisRepository
+public class TokenBlacklistRedisDao extends BaseRedisRepository<Boolean> {
+
+    @Autowired
+    public TokenBlacklistRedisDao(RedisTemplate<String, Boolean> redisTemplate) {
+        this.prefix = BLACKlIST_PREFIX;
+        this.redisTemplate = redisTemplate; // id랑 리프레쉬 토큰
+    }
+}

--- a/src/main/java/com/haertz/be/auth/repository/UserRepository.java
+++ b/src/main/java/com/haertz/be/auth/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.haertz.be.auth.repository;
+
+import com.haertz.be.auth.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByAuthInfoEmail(String email);
+
+    Boolean existsByAuthInfoEmail(String email);
+}

--- a/src/main/java/com/haertz/be/auth/service/RefreshTokenRedisService.java
+++ b/src/main/java/com/haertz/be/auth/service/RefreshTokenRedisService.java
@@ -1,0 +1,37 @@
+package com.haertz.be.auth.service;
+
+import com.haertz.be.auth.adaptor.RefreshTokenRedisAdaptor;
+import com.haertz.be.auth.entity.RefreshToken;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import static com.haertz.be.common.constant.StaticValue.REFRESH_TOKEN_PREFIX;
+
+@Service
+@RequiredArgsConstructor // 레디스 RefreshToken infrastructure 서비스
+public class RefreshTokenRedisService {
+    private final RefreshTokenRedisAdaptor refreshTokenRedisAdaptor;
+
+    @Value("${jwt.refresh-token-exp}")
+    private Long refreshTokenExp;
+
+    public void save(Long id, String token) {
+        RefreshToken refreshToken = RefreshToken.builder()
+                .userId(id)
+                .token(token)
+                .build();
+        refreshTokenRedisAdaptor.save(id, refreshToken, refreshTokenExp);
+    }
+
+    public Boolean checkToken(Long id, String token) {
+        RefreshToken refreshToken = refreshTokenRedisAdaptor.findById(id);
+        if (token.equals(refreshToken.getToken())) return true;
+        else return false;
+    }
+
+    public void deleteByUserId(Long userId) {
+        String key = REFRESH_TOKEN_PREFIX + userId;
+        refreshTokenRedisAdaptor.deleteByKey(key);
+    }
+}

--- a/src/main/java/com/haertz/be/auth/service/TokenBlacklistRedisService.java
+++ b/src/main/java/com/haertz/be/auth/service/TokenBlacklistRedisService.java
@@ -1,0 +1,27 @@
+package com.haertz.be.auth.service;
+
+import com.haertz.be.auth.adaptor.TokenBlacklistRedisAdaptor;
+import com.haertz.be.common.exception.GlobalErrorCode;
+import com.haertz.be.common.exception.base.BaseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TokenBlacklistRedisService {
+    private final TokenBlacklistRedisAdaptor tokenBlacklistRedisAdaptor;
+
+    @Value("${jwt.access-token-exp}")
+    private Long accessTokenExp;
+
+    public void save(String accessToken) {
+        tokenBlacklistRedisAdaptor.save(accessToken, accessTokenExp);
+    }
+
+    public void checkTokenBlacklisted(String accessToken) {
+        if (tokenBlacklistRedisAdaptor.hasKey(accessToken)) {
+            throw new BaseException(GlobalErrorCode.TOKEN_BLACKLISTED);
+        }
+    }
+}

--- a/src/main/java/com/haertz/be/auth/service/UserDomainService.java
+++ b/src/main/java/com/haertz/be/auth/service/UserDomainService.java
@@ -1,0 +1,44 @@
+package com.haertz.be.auth.service;
+
+import com.haertz.be.auth.adaptor.UserAdaptor;
+import com.haertz.be.auth.entity.AccountStatus;
+import com.haertz.be.auth.entity.AuthInfo;
+import com.haertz.be.auth.entity.LoginType;
+import com.haertz.be.auth.entity.User;
+import com.haertz.be.auth.exception.UserErrorCode;
+import com.haertz.be.common.exception.base.BaseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor // 사용자를 관리하는 클래스
+public class UserDomainService {
+    private final UserAdaptor userAdaptor;
+
+    @Transactional(readOnly = true)
+    public User login(LoginType loginType, String email) {
+        User user = userAdaptor.findByEmail(email);
+        validateUser(user, loginType);
+        return user;
+    }
+
+    private void validateUser(User user, LoginType loginType) {
+        if (!user.getAuthInfo().getLoginType().equals(loginType)) {
+            throw new BaseException(UserErrorCode.EMAIL_ALREADY_REGISTERED);
+        }
+    }
+
+    @Transactional
+    public User signUp(String name, AuthInfo authInfo) {
+        User user = User.builder()
+                .userName(name)
+                .authInfo(authInfo)
+                .build();
+        return userAdaptor.save(user);
+    }
+
+    
+}

--- a/src/main/java/com/haertz/be/auth/usecase/LoginUseCase.java
+++ b/src/main/java/com/haertz/be/auth/usecase/LoginUseCase.java
@@ -1,0 +1,36 @@
+package com.haertz.be.auth.usecase;
+
+import com.haertz.be.auth.adaptor.UserAdaptor;
+import com.haertz.be.auth.dto.response.AccountTokenDto;
+import com.haertz.be.auth.entity.LoginType;
+import com.haertz.be.auth.exception.UserErrorCode;
+import com.haertz.be.auth.entity.User;
+import com.haertz.be.auth.service.UserDomainService;
+import com.haertz.be.auth.usecase.processor.GenerateAccountTokenProcessor;
+import com.haertz.be.auth.usecase.processor.GoogleOauthProcessor;
+import com.haertz.be.common.annotation.UseCase;
+import com.haertz.be.common.exception.base.BaseException;
+import com.haertz.be.common.jwt.dto.UserInfoFromIdToken;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class LoginUseCase {
+    private final GoogleOauthProcessor googleOauthProcessor;
+    private final UserAdaptor userAdaptor;
+    private final UserDomainService userDomainService;
+    private final GenerateAccountTokenProcessor generateAccountTokenProcessor;
+
+    public AccountTokenDto execute(String loginType, String idToken, HttpServletResponse response) {
+        if (loginType.equals("google")) {
+            UserInfoFromIdToken userInfo = googleOauthProcessor.getUserInfoByIdToken(idToken);
+            if (!userAdaptor.existsByEmail(userInfo.getEmail())) {
+                return AccountTokenDto.notRegistered();
+            }
+
+            User user = userDomainService.login(LoginType.fromValue(loginType), userInfo.getEmail());
+            return generateAccountTokenProcessor.createToken(user,  response);
+        }throw new BaseException(UserErrorCode.NOT_SUPPORTED_LOGINTYPE_ERROR);
+    }
+}

--- a/src/main/java/com/haertz/be/auth/usecase/LogoutUseCase.java
+++ b/src/main/java/com/haertz/be/auth/usecase/LogoutUseCase.java
@@ -1,0 +1,28 @@
+package com.haertz.be.auth.usecase;
+
+import com.haertz.be.auth.entity.User;
+import com.haertz.be.auth.service.RefreshTokenRedisService;
+import com.haertz.be.auth.service.TokenBlacklistRedisService;
+import com.haertz.be.auth.usecase.processor.CookieProcessor;
+import com.haertz.be.common.annotation.UseCase;
+import com.haertz.be.common.utils.AuthenticatedUserUtils;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class LogoutUseCase {
+    private final RefreshTokenRedisService refreshTokenRedisService;
+    private final TokenBlacklistRedisService tokenBlacklistRedisService;
+    private final AuthenticatedUserUtils userUtils;
+    private final CookieProcessor cookieProcessor;
+
+
+    public void execute(String accessToken, HttpServletResponse response){
+        User user = userUtils.getCurrentUser();
+        refreshTokenRedisService.deleteByUserId(user.getUserId());
+        cookieProcessor.clearRefreshTokenCookie(response);
+        tokenBlacklistRedisService.save(accessToken);
+
+    }
+}

--- a/src/main/java/com/haertz/be/auth/usecase/RefreshTokenUseCase.java
+++ b/src/main/java/com/haertz/be/auth/usecase/RefreshTokenUseCase.java
@@ -1,0 +1,36 @@
+package com.haertz.be.auth.usecase;
+
+import com.haertz.be.auth.adaptor.UserAdaptor;
+import com.haertz.be.auth.dto.response.AccountTokenDto;
+import com.haertz.be.auth.entity.User;
+import com.haertz.be.auth.service.RefreshTokenRedisService;
+import com.haertz.be.auth.usecase.processor.GenerateAccountTokenProcessor;
+import com.haertz.be.common.annotation.UseCase;
+import com.haertz.be.common.exception.GlobalErrorCode;
+import com.haertz.be.common.exception.base.BaseException;
+import com.haertz.be.common.jwt.JwtProvider;
+import com.haertz.be.common.jwt.dto.DecodedJwtToken;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+import static com.haertz.be.common.constant.StaticValue.REFRESH_TOKEN;
+
+
+@UseCase
+@RequiredArgsConstructor
+public class RefreshTokenUseCase {
+    private final RefreshTokenRedisService refreshTokenRedisService;
+    private final GenerateAccountTokenProcessor generateAccountTokenProcessor;
+    private final JwtProvider jwtProvider;
+    private final UserAdaptor userAdaptor;
+
+    public AccountTokenDto execute(String refreshToken, HttpServletResponse response) {
+        DecodedJwtToken decodedJwtToken = jwtProvider.decodedToken(refreshToken, REFRESH_TOKEN);
+        User user = userAdaptor.findById(decodedJwtToken.getUserId());
+
+        if (refreshTokenRedisService.checkToken(user.getUserId(), refreshToken)) {
+            return generateAccountTokenProcessor.refreshToken(user, refreshToken, response);
+        } else throw new BaseException(GlobalErrorCode.INVALID_TOKEN);
+    }
+
+}

--- a/src/main/java/com/haertz/be/auth/usecase/RequestTokenUseCase.java
+++ b/src/main/java/com/haertz/be/auth/usecase/RequestTokenUseCase.java
@@ -1,0 +1,23 @@
+package com.haertz.be.auth.usecase;
+
+import com.haertz.be.auth.dto.response.IdTokenDto;
+import com.haertz.be.auth.exception.UserErrorCode;
+import com.haertz.be.auth.usecase.processor.GoogleOauthProcessor;
+import com.haertz.be.common.annotation.UseCase;
+import com.haertz.be.common.exception.base.BaseException;
+import com.haertz.be.common.feign.GoogleTokenResponse;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class RequestTokenUseCase {
+    private final GoogleOauthProcessor googleOauthProcessor;
+
+    public IdTokenDto execute(String loginType, String code) {
+        if (loginType.equals("google")) {
+            GoogleTokenResponse googleTokenResponse = googleOauthProcessor.getOauthToken(code);
+            return IdTokenDto.of(googleTokenResponse.getIdToken());
+        }
+        throw new BaseException(UserErrorCode.NOT_SUPPORTED_LOGINTYPE_ERROR);
+    }
+}

--- a/src/main/java/com/haertz/be/auth/usecase/SignUpUseCase.java
+++ b/src/main/java/com/haertz/be/auth/usecase/SignUpUseCase.java
@@ -1,0 +1,40 @@
+package com.haertz.be.auth.usecase;
+
+import com.haertz.be.auth.adaptor.UserAdaptor;
+import com.haertz.be.auth.dto.response.AccountTokenDto;
+import com.haertz.be.auth.entity.AuthInfo;
+import com.haertz.be.auth.entity.LoginType;
+import com.haertz.be.auth.entity.User;
+import com.haertz.be.auth.exception.UserErrorCode;
+import com.haertz.be.auth.service.UserDomainService;
+import com.haertz.be.auth.usecase.processor.GenerateAccountTokenProcessor;
+import com.haertz.be.auth.usecase.processor.GoogleOauthProcessor;
+import com.haertz.be.common.annotation.UseCase;
+import com.haertz.be.common.exception.base.BaseException;
+import com.haertz.be.common.jwt.dto.UserInfoFromIdToken;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class SignUpUseCase {
+    private final UserDomainService userDomainService;
+
+    private final UserAdaptor userAdaptor;
+    private final GoogleOauthProcessor googleOauthProcessor;
+    private final GenerateAccountTokenProcessor generateAccountTokenProcessor;
+
+
+    public AccountTokenDto execute(String loginType, String idToken, HttpServletResponse response){
+        if (loginType.equals("google")) {
+            UserInfoFromIdToken userInfo = googleOauthProcessor.getUserInfoByIdToken(idToken);
+
+            if (!userAdaptor.existsByEmail(userInfo.getEmail())) {
+                AuthInfo authInfo = AuthInfo.authInfoForSignUp((LoginType.fromValue(loginType)), userInfo.getEmail());
+                User user = userDomainService.signUp(userInfo.getName(), authInfo);
+                return generateAccountTokenProcessor.createToken(user, response);
+            } else throw new BaseException(UserErrorCode.EMAIL_ALREADY_REGISTERED);
+        }
+        throw new BaseException(UserErrorCode.NOT_SUPPORTED_LOGINTYPE_ERROR);
+    }
+}

--- a/src/main/java/com/haertz/be/auth/usecase/processor/CookieProcessor.java
+++ b/src/main/java/com/haertz/be/auth/usecase/processor/CookieProcessor.java
@@ -1,0 +1,33 @@
+package com.haertz.be.auth.usecase.processor;
+
+import com.haertz.be.common.annotation.Processor;
+import com.haertz.be.common.jwt.properties.JwtProperties;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Processor
+@RequiredArgsConstructor
+public class CookieProcessor {
+
+    private final JwtProperties jwtProperties;
+    public void setRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
+        Cookie refreshTokenCookie = new Cookie("refreshToken", refreshToken);
+        refreshTokenCookie.setHttpOnly(true); // xss 공격 방어
+        refreshTokenCookie.setSecure(false); // 추후 true로 변경
+        refreshTokenCookie.setPath("/");
+        refreshTokenCookie.setMaxAge(jwtProperties.getRefreshTokenExp());
+        response.addCookie(refreshTokenCookie);
+    }
+
+    public void clearRefreshTokenCookie(HttpServletResponse response) {
+        Cookie refreshTokenCookie = new Cookie("refreshToken", null);
+        refreshTokenCookie.setHttpOnly(true); // xss 공격 방어
+        refreshTokenCookie.setSecure(false); // 추후 true로 변경
+        refreshTokenCookie.setPath("/");
+        refreshTokenCookie.setMaxAge(0);
+        response.addCookie(refreshTokenCookie);
+    }
+}
+
+

--- a/src/main/java/com/haertz/be/auth/usecase/processor/GenerateAccountTokenProcessor.java
+++ b/src/main/java/com/haertz/be/auth/usecase/processor/GenerateAccountTokenProcessor.java
@@ -1,0 +1,32 @@
+package com.haertz.be.auth.usecase.processor;
+
+import com.haertz.be.auth.dto.response.AccountTokenDto;
+import com.haertz.be.auth.entity.User;
+import com.haertz.be.auth.service.RefreshTokenRedisService;
+import com.haertz.be.common.annotation.Processor;
+import com.haertz.be.common.jwt.JwtProvider;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+import static com.haertz.be.common.constant.StaticValue.ACCESS_TOKEN;
+import static com.haertz.be.common.constant.StaticValue.REFRESH_TOKEN;
+
+@Processor
+@RequiredArgsConstructor
+public class GenerateAccountTokenProcessor {
+    private final JwtProvider jwtProvider;
+    private final CookieProcessor cookieProcessor;
+    private final RefreshTokenRedisService refreshTokenRedisService;
+
+    // [유저]를 받아서, 액세스/리프레쉬 토큰을 만들고 AccountTokenDto를 만든다.
+    public AccountTokenDto createToken(User user, HttpServletResponse response){
+        String accessToken = jwtProvider.generateToken(user.getUserId(),user.getAuthInfo().getRole().getValue(),ACCESS_TOKEN);
+        String refreshToken = jwtProvider.generateToken(user.getUserId(),user.getAuthInfo().getRole().getValue(), REFRESH_TOKEN);
+
+        refreshTokenRedisService.save(user.getUserId(), refreshToken); // redis에 userId와 refreshToken 저장
+        cookieProcessor.setRefreshTokenCookie(response, refreshToken);
+
+        return AccountTokenDto.of(accessToken);
+    }
+
+}

--- a/src/main/java/com/haertz/be/auth/usecase/processor/GenerateAccountTokenProcessor.java
+++ b/src/main/java/com/haertz/be/auth/usecase/processor/GenerateAccountTokenProcessor.java
@@ -29,4 +29,14 @@ public class GenerateAccountTokenProcessor {
         return AccountTokenDto.of(accessToken);
     }
 
+    // [유저와 리프레쉬 토큰]을 받아서, 액세스 토큰을 만들고, AccountTokenDto을 만든다.
+    public AccountTokenDto refreshToken(User user, String refreshToken, HttpServletResponse response){
+        String accessToken = jwtProvider.generateToken(user.getUserId(),user.getAuthInfo().getRole().getValue(),ACCESS_TOKEN);
+
+        refreshTokenRedisService.save(user.getUserId(), refreshToken); // redis refreshToken exp 갱신
+        cookieProcessor.setRefreshTokenCookie(response, refreshToken);
+
+        return AccountTokenDto.of(accessToken);
+
+    }
 }

--- a/src/main/java/com/haertz/be/auth/usecase/processor/GoogleOauthProcessor.java
+++ b/src/main/java/com/haertz/be/auth/usecase/processor/GoogleOauthProcessor.java
@@ -1,0 +1,56 @@
+package com.haertz.be.auth.usecase.processor;
+
+import com.haertz.be.common.annotation.Processor;
+import com.haertz.be.common.feign.GoogleOAuthApi;
+import com.haertz.be.common.feign.GoogleTokenResponse;
+import com.haertz.be.common.feign.oidc.GoogleOIDCApi;
+import com.haertz.be.common.feign.oidc.OIDCPublicKeysResponse;
+import com.haertz.be.common.jwt.OAuthOIDCProcessor;
+import com.haertz.be.common.jwt.dto.OIDCDecodePayload;
+import com.haertz.be.common.jwt.dto.UserInfoFromIdToken;
+import com.haertz.be.common.jwt.properties.OauthProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import static com.haertz.be.common.constant.StaticValue.GOOGLE_GRANT_TYPE;
+import static com.haertz.be.common.constant.StaticValue.GOOGLE_ISS_URL;
+
+
+@Slf4j
+@Processor
+@RequiredArgsConstructor
+public class GoogleOauthProcessor {
+    private final OAuthOIDCProcessor oAuthOIDCProcessor;
+    private final GoogleOIDCApi googleOIDCApi;
+    private final GoogleOAuthApi googleOAuthApi;
+    private final OauthProperties oauthProperties;
+
+    public GoogleTokenResponse getOauthToken(String code) {
+        return googleOAuthApi.getGoogleToken(
+                code,
+                oauthProperties.getGoogleClientId(),
+                oauthProperties.getGoogleClientSecret(),
+                oauthProperties.getGoogleRedirectUri(),
+                GOOGLE_GRANT_TYPE);
+    }
+
+    // 구글 공개키 리스트 가져온 후, idToken을 디코딩하고 검증하고 idToken 정보를 반환한다
+    public OIDCDecodePayload getOIDCDecodePayload(String idtoken) {
+        OIDCPublicKeysResponse oidcPublicKeysResponse = googleOIDCApi.getGoogleOIDCOpenKeys();
+        return oAuthOIDCProcessor.getPayloadFromIdToken(
+                idtoken,
+                GOOGLE_ISS_URL, // iss
+                oauthProperties.getGoogleClientId(), // aud
+                oidcPublicKeysResponse);
+    }
+
+    // idToken에서 메일과 이름을 추출하여 반환한다
+    public UserInfoFromIdToken getUserInfoByIdToken(String idToken) {
+        OIDCDecodePayload oidcDecodePayload = getOIDCDecodePayload(idToken);
+        return UserInfoFromIdToken.builder()
+                .name(oidcDecodePayload.getName())
+                .email(oidcDecodePayload.getEmail())
+                .build();
+    }
+
+}

--- a/src/main/java/com/haertz/be/common/annotation/Adaptor.java
+++ b/src/main/java/com/haertz/be/common/annotation/Adaptor.java
@@ -1,0 +1,15 @@
+package com.haertz.be.common.annotation;
+
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Component
+public @interface Adaptor {
+    String value() default "";
+}

--- a/src/main/java/com/haertz/be/common/annotation/Processor.java
+++ b/src/main/java/com/haertz/be/common/annotation/Processor.java
@@ -1,0 +1,15 @@
+package com.haertz.be.common.annotation;
+
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Component
+public @interface Processor {
+}

--- a/src/main/java/com/haertz/be/common/annotation/RedisRepository.java
+++ b/src/main/java/com/haertz/be/common/annotation/RedisRepository.java
@@ -1,0 +1,15 @@
+package com.haertz.be.common.annotation;
+
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Component
+public @interface RedisRepository {
+    String value()  default "";
+}

--- a/src/main/java/com/haertz/be/common/annotation/UseCase.java
+++ b/src/main/java/com/haertz/be/common/annotation/UseCase.java
@@ -1,0 +1,16 @@
+package com.haertz.be.common.annotation;
+
+
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Component
+public @interface UseCase {
+    String value() default "";
+}

--- a/src/main/java/com/haertz/be/common/config/GoogleOAuthConfig.java
+++ b/src/main/java/com/haertz/be/common/config/GoogleOAuthConfig.java
@@ -1,0 +1,11 @@
+package com.haertz.be.common.config;
+
+import feign.codec.Encoder;
+import org.springframework.context.annotation.Bean;
+public class GoogleOAuthConfig {
+    // Feign 클라이언트에서 Form-encoded 방식으로 데이터 인코딩 하기 위한 목적
+    @Bean
+    Encoder formEncoder(){
+        return new feign.form.FormEncoder();
+    }
+}

--- a/src/main/java/com/haertz/be/common/config/JpaAuditingConfig.java
+++ b/src/main/java/com/haertz/be/common/config/JpaAuditingConfig.java
@@ -1,0 +1,12 @@
+package com.haertz.be.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+/*
+BaseEntity 자동 관리 설정 클래스
+ */
+@EnableJpaAuditing
+@Configuration
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/haertz/be/common/config/RedisCacheConfig.java
+++ b/src/main/java/com/haertz/be/common/config/RedisCacheConfig.java
@@ -1,0 +1,29 @@
+package com.haertz.be.common.config;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+// Redis를 캐시 저장소로 사용
+@Configuration
+public class RedisCacheConfig {
+    @Bean
+    public CacheManager oidcCacheManager(RedisConnectionFactory cf){
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig() // 기본 캐시 설정
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer())) // 캐시 키 문자열 형태로 직렬화
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer((new GenericJackson2JsonRedisSerializer()))) // 캐시 값 json 형태로 직렬화
+                .entryTtl(Duration.ofDays(7L)); // 캐시 데이터 유효기간 7일로 설정
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf)
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
+    }
+
+}

--- a/src/main/java/com/haertz/be/common/config/RedisConfig.java
+++ b/src/main/java/com/haertz/be/common/config/RedisConfig.java
@@ -1,0 +1,59 @@
+package com.haertz.be.common.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisPassword;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.password}") // 비밀번호를 주입받습니다.
+    private String password; // 비밀번호를 저장할 필드 추가
+
+    public ObjectMapper redisObjectMapper() {
+        PolymorphicTypeValidator typeValidator = BasicPolymorphicTypeValidator.builder()
+                .allowIfSubType(Object.class)
+                .build();
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mapper.registerModule(new JavaTimeModule());
+        mapper.activateDefaultTyping(typeValidator, ObjectMapper.DefaultTyping.NON_FINAL);
+        return mapper;
+    }
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration(host, port);
+        redisStandaloneConfiguration.setPassword(RedisPassword.of(password));
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+
+    @Bean
+    public <T> RedisTemplate<String, T> redisTemplate() {
+        RedisTemplate<String, T> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer(redisObjectMapper()));
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/haertz/be/common/config/SwaggerConfig.java
+++ b/src/main/java/com/haertz/be/common/config/SwaggerConfig.java
@@ -1,0 +1,39 @@
+package com.haertz.be.common.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        Info info = new Info()
+                .version("v1.0.0")
+                .title("Blaybus 8haertz API")
+                .description("Blaybus 8haertz API입니다");
+
+        String jwt = "JWT";
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwt); // 헤더에 토큰 포함
+        SecurityScheme securityScheme = new SecurityScheme()
+                .name(jwt)
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT");
+
+        Components components = new Components().addSecuritySchemes(jwt, securityScheme);
+
+        return new OpenAPI()
+                .addServersItem(new Server().url("/"))
+                .info(info)
+                .addSecurityItem(securityRequirement)
+                .components(components);
+
+    }
+}

--- a/src/main/java/com/haertz/be/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/haertz/be/common/config/security/SecurityConfig.java
@@ -1,0 +1,96 @@
+package com.haertz.be.common.config.security;
+;
+import com.haertz.be.common.jwt.filter.CustomAccessDeniedHandler;
+import com.haertz.be.common.jwt.filter.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.expression.DefaultWebSecurityExpressionHandler;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable) // HTTP 기본 인증 비활성화
+                .sessionManagement((session) -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(swaggerUrlPatterns).permitAll()
+                        .requestMatchers("/api/auth/login").permitAll()
+                        .requestMatchers("/api/**").permitAll() // 임시로 추가 TODO 삭제 예정
+                        .requestMatchers("/login/oauth2/**").permitAll()  // OAuth 로그인 경로 허용
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtAuthenticationFilter, BasicAuthenticationFilter.class)
+                .exceptionHandling(customizer -> customizer
+                        .accessDeniedHandler(customAccessDeniedHandler))
+
+                .build();
+    }
+
+    @Bean
+    public BCryptPasswordEncoder encoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean // 사용자 역할 간의 계층 구조를 정의함F
+    public RoleHierarchy roleHierarchy() {
+        String hierarchy = "ROLE_USER";
+        return RoleHierarchyImpl.fromHierarchy(hierarchy);
+    }
+
+    @Bean // url 접근 제어 및 권한 검사 하는 데 사용되는 핸들러 = DefaultWebSecurityExpressionHandler
+    public DefaultWebSecurityExpressionHandler expressionHandler() {
+        DefaultWebSecurityExpressionHandler expressionHandler = new DefaultWebSecurityExpressionHandler();
+        expressionHandler.setRoleHierarchy(roleHierarchy());
+        return expressionHandler;
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of("http://localhost:3000", "http://localhost:8080"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        configuration.setAllowCredentials(true);
+        configuration.setAllowedHeaders(List.of("Authorization", "Content-Type"));
+        configuration.setExposedHeaders(List.of("Authorization"));
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+
+    private final String[] swaggerUrlPatterns = {
+            "/v3/api-docs/**",
+            "/swagger-resources",
+            "/swagger-resources/**",
+            "/swagger-ui/**",
+            "/swagger-ui.html",
+    };
+
+
+}
+

--- a/src/main/java/com/haertz/be/common/config/security/SecurityUtils.java
+++ b/src/main/java/com/haertz/be/common/config/security/SecurityUtils.java
@@ -1,0 +1,19 @@
+package com.haertz.be.common.config.security;
+
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+//  현재 인증 정보를 가져온 후 사용자 id 추출
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SecurityUtils {
+    public static Long getCurrentUserId(){
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.isAuthenticated() && authentication.getPrincipal() instanceof Long){
+            return (Long) authentication.getPrincipal();
+        }
+        else return 0L;
+    }
+}

--- a/src/main/java/com/haertz/be/common/constant/StaticValue.java
+++ b/src/main/java/com/haertz/be/common/constant/StaticValue.java
@@ -1,0 +1,11 @@
+package com.haertz.be.common.constant;
+
+public class StaticValue {
+    public static final String ACCESS_TOKEN = "AccessToken";
+    public static final String REFRESH_TOKEN = "RefreshToken";
+    public static final String GOOGLE_BASIC_OAUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth?client_id=%s&redirect_uri=%s&response_type=code&scope=%s";
+    public static final String GOOGLE_ISS_URL = "https://accounts.google.com";
+    public static final String GOOGLE_GRANT_TYPE = "authorization_code";
+    public static final String REFRESH_TOKEN_PREFIX = "refreshToken:";
+    public static final String BLACKlIST_PREFIX = "blacklist:";
+}

--- a/src/main/java/com/haertz/be/common/entity/BaseTimeEntity.java
+++ b/src/main/java/com/haertz/be/common/entity/BaseTimeEntity.java
@@ -1,0 +1,22 @@
+package com.haertz.be.common.entity;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedDate;
+}

--- a/src/main/java/com/haertz/be/common/exception/GlobalErrorCode.java
+++ b/src/main/java/com/haertz/be/common/exception/GlobalErrorCode.java
@@ -1,0 +1,44 @@
+package com.haertz.be.common.exception;
+
+import com.haertz.be.common.exception.base.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum GlobalErrorCode implements BaseErrorCode {
+
+    DUPLICATED_KEY(200,"DUPLICATED_KEY_409_1", "중복된 값으로 인해 예외가 발생했습니다."), //사용자 입력 오류값
+    TOKEN_BLACKLISTED(200,"TOKEN_401_6", "블랙리스트에 등록된 accessToken입니다."), //사용자 입력 오류값
+
+    BAD_REQUEST_ERROR(400, "GLOBAL_400_1", "잘못된 요청입니다."),
+
+    INVALID_HTTP_MESSAGE_BODY(400, "GLOBAL_400_2", "HTTP 요청 바디의 형식이 잘못되었습니다."),
+    INVALID_REQUEST_CONTENT(400, "GLOBAL_400_3", "잘못된 데이터를 포함한 요청입니다."),
+    ACCESS_DENIED_REQUEST(403, "GLOBAL_403", "해당 요청에 접근 권한이 없습니다."),
+    HEADER_VALUE_NOT_FOUND(404,"GLOBAL_404_1","헤더에 값이 존재하지 않습니다."),
+    UNSUPPORTED_HTTP_METHOD(405, "GLOBAL_405", "지원하지 않는 HTTP 메소드입니다."),
+    SERVER_ERROR(500, "GLOBAL_500", "서버 내부에서 알 수 없는 오류가 발생했습니다."),
+
+    NOT_AUTHENTICATED_ERROR(401, "SECURITY_401", "사용자가 인증되지 않았습니다."),
+
+    INVALID_TOKEN(401, "TOKEN_401_1", "토큰이 유효하지 않습니다."),
+    OAUTH_ACCESS_TOKEN_NOT_FOUND(401, "TOKEN_401_2","OAUTH ACCESS 토큰이 유효하지 않습니다."),
+    INVALID_SIGNATURE_TOKEN(401, "TOKEN_401_3", "토큰의 서명 검증 과정에서 오류가 생겼습니다."),
+    INCORRECT_ISSUER_TOKEN(401, "TOKEN_401_4", "토큰 발급처가 일치하지 않습니다."),
+    EXPIRED_TOKEN(401, "TOKEN_401_5", "토큰이 만료되었습니다."),
+    NOT_MATCHED_TOKEN_TYPE(401, "TOKEN_401_6", "토큰의 타입이 일치하지 않아 디코딩할 수 없습니다."),
+
+    TOKEN_HEADER_NOT_FOUND(404,"TOKEN_404_1","토큰에 KID가 존재하지 않습니다."),
+
+    PUBKEY_GENERATION_FAILED(400, "PUBLIC_KEY_400", "공개키를 생성하는데 실패했습니다."),
+
+    REDIS_ID_NOT_FOUND(404, "REDIS_404", "REDIS ID가 존재하지 않습니다."),
+    REDIS_SAVE_FAILED(404, "REDIS_404_2", "REDIS에서 값을 저장하는 과정에서 오류가 발생했습니다."),
+    REDIS_DELETE_FAILED(500,"REDIS_500","REDIS에서 값을 삭제하는 과정에서 오류가 발생했습니다.");
+
+    private final int httpStatus;
+    private final String code;
+    private final String message;
+
+}

--- a/src/main/java/com/haertz/be/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/haertz/be/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,62 @@
+package com.haertz.be.common.exception;
+
+import com.haertz.be.auth.controller.AuthController;
+import com.haertz.be.common.exception.base.BaseErrorCode;
+import com.haertz.be.common.exception.base.BaseException;
+import com.haertz.be.common.response.ErrorResponse;
+import com.haertz.be.user.controller.UserController;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.sql.SQLIntegrityConstraintViolationException;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler({ SQLIntegrityConstraintViolationException.class, DataIntegrityViolationException.class })
+    public ResponseEntity<ErrorResponse> handleSQLIntegrityConstraintViolationException(Exception ex) {
+        log.error("중복된 값으로 인해 예외가 발생했습니다: {}", ex.getMessage(), ex);
+        return makeErrorResponse(GlobalErrorCode.DUPLICATED_KEY);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request)
+    {
+        // 첫 번째 유효성 검사 오류 가져오기
+        String errorMessage = ex.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+
+        ErrorResponse errorResponse = ErrorResponse.fromErrorCodeWithCustomMessage(GlobalErrorCode.INVALID_REQUEST_CONTENT, errorMessage);
+
+        return ResponseEntity.status(GlobalErrorCode.INVALID_REQUEST_CONTENT.getHttpStatus()).body(errorResponse);
+    }
+
+    @ExceptionHandler(BaseException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(BaseException e) {
+        StackTraceElement element = e.getStackTrace()[0];
+        String className = element.getClassName();
+        String methodName = element.getMethodName();
+
+        // 로그에 예외가 발생한 클래스와 메서드명 추가
+        log.error("Exception occurred in {}.{}: {}", className, methodName, e.getErrorCode().getMessage());
+        BaseErrorCode errorCode = e.getErrorCode();
+        return makeErrorResponse(errorCode);
+    }
+
+    private ResponseEntity<ErrorResponse> makeErrorResponse(BaseErrorCode errorCode) {
+        ErrorResponse res = ErrorResponse.fromErrorCode(errorCode);
+
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(res);
+    }
+
+}

--- a/src/main/java/com/haertz/be/common/exception/base/BaseErrorCode.java
+++ b/src/main/java/com/haertz/be/common/exception/base/BaseErrorCode.java
@@ -1,0 +1,7 @@
+package com.haertz.be.common.exception.base;
+
+public interface BaseErrorCode {
+    public String getCode();
+    public String getMessage();
+    public int getHttpStatus();
+}

--- a/src/main/java/com/haertz/be/common/exception/base/BaseException.java
+++ b/src/main/java/com/haertz/be/common/exception/base/BaseException.java
@@ -1,0 +1,11 @@
+package com.haertz.be.common.exception.base;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class BaseException extends RuntimeException{
+    private final BaseErrorCode errorCode;
+}

--- a/src/main/java/com/haertz/be/common/feign/GoogleOAuthApi.java
+++ b/src/main/java/com/haertz/be/common/feign/GoogleOAuthApi.java
@@ -1,0 +1,25 @@
+package com.haertz.be.common.feign;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import com.haertz.be.common.config.GoogleOAuthConfig;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+// 구글로부터, 액세스/리프레쉬/Id/scope를 받아옵니다.
+@FeignClient(
+        name = "GoogleOAuth",
+        url = "https://oauth2.googleapis.com",
+        configuration = GoogleOAuthConfig.class )
+public interface GoogleOAuthApi {
+    @PostMapping(
+            value = "/token",
+            produces = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    GoogleTokenResponse getGoogleToken(
+            @RequestParam("code") String code,
+            @RequestParam("client_id") String clientId,
+            @RequestParam("client_secret") String clientSecret,
+            @RequestParam("redirect_uri") String redirectUri,
+            @RequestParam("grant_type") String grantType
+    );
+}

--- a/src/main/java/com/haertz/be/common/feign/GoogleTokenResponse.java
+++ b/src/main/java/com/haertz/be/common/feign/GoogleTokenResponse.java
@@ -1,0 +1,24 @@
+package com.haertz.be.common.feign;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+public class GoogleTokenResponse {
+    @NotNull(message = "accessToken may not be null")
+    @JsonProperty("access_token")
+    private String accessToken;
+    @JsonProperty("id_token")
+    private String idToken;
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+    @JsonProperty("scope")
+    private String scope;
+}

--- a/src/main/java/com/haertz/be/common/feign/oidc/GoogleOIDCApi.java
+++ b/src/main/java/com/haertz/be/common/feign/oidc/GoogleOIDCApi.java
@@ -1,0 +1,16 @@
+package com.haertz.be.common.feign.oidc;
+
+import com.haertz.be.common.config.GoogleOAuthConfig;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@FeignClient(
+        name = "GoogleOIDCApi",
+        url = "https://www.googleapis.com/oauth2",
+        configuration = GoogleOAuthConfig.class)
+public interface GoogleOIDCApi {
+    @Cacheable(cacheNames = "GoogleOICD", cacheManager = "oidcCacheManager")
+    @GetMapping("/v3/certs")
+    OIDCPublicKeysResponse getGoogleOIDCOpenKeys();
+}

--- a/src/main/java/com/haertz/be/common/feign/oidc/OIDCPublicKeyDto.java
+++ b/src/main/java/com/haertz/be/common/feign/oidc/OIDCPublicKeyDto.java
@@ -1,0 +1,14 @@
+package com.haertz.be.common.feign.oidc;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor // 공개키를 담는 dto
+public class OIDCPublicKeyDto {
+    private String kid;
+    private String alg; // 알고리즘
+    private String use;
+    private String n; // modulus
+    private String e; // exponent
+}

--- a/src/main/java/com/haertz/be/common/feign/oidc/OIDCPublicKeysResponse.java
+++ b/src/main/java/com/haertz/be/common/feign/oidc/OIDCPublicKeysResponse.java
@@ -1,0 +1,12 @@
+package com.haertz.be.common.feign.oidc;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class OIDCPublicKeysResponse {
+    List<OIDCPublicKeyDto> keys;
+}

--- a/src/main/java/com/haertz/be/common/jwt/FilterExceptionProcessor.java
+++ b/src/main/java/com/haertz/be/common/jwt/FilterExceptionProcessor.java
@@ -1,0 +1,33 @@
+package com.haertz.be.common.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.haertz.be.common.annotation.Processor;
+import com.haertz.be.common.exception.base.BaseException;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+// Spring Security 필터에서 발생한 예외
+@Processor
+@RequiredArgsConstructor
+public class FilterExceptionProcessor {
+
+    private final ObjectMapper objectMapper;
+
+    public void excute(HttpServletResponse response, BaseException e) throws IOException {
+        Map<String, Object> errorResponse = new HashMap<>();
+        errorResponse.put("timestamp", LocalDateTime.now());
+        errorResponse.put("isSuccess", false);
+        errorResponse.put("message", e.getErrorCode().getMessage());
+        errorResponse.put("code", e.getErrorCode());
+
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(e.getErrorCode().getHttpStatus());
+        response.setContentType("application/json");
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse)); // json 문자열이 응답 본문에 작성된다.
+    }
+}

--- a/src/main/java/com/haertz/be/common/jwt/JwtOIDCProvider.java
+++ b/src/main/java/com/haertz/be/common/jwt/JwtOIDCProvider.java
@@ -1,0 +1,99 @@
+package com.haertz.be.common.jwt;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.haertz.be.common.exception.GlobalErrorCode;
+import com.haertz.be.common.exception.base.BaseException;
+import com.haertz.be.common.jwt.dto.OIDCDecodePayload;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+//ID 토큰에서의 정보(클레임)을 추출한다.
+public class JwtOIDCProvider {
+
+    // JWT의 헤더에서 kid를 추출하는 메서드
+    public String getKidFromToken(String token) {
+        String[] splitToken = token.split("\\.");
+        if (splitToken.length != 3) throw new BaseException(GlobalErrorCode.INVALID_TOKEN);
+
+        String headerJson = new String(Base64.getUrlDecoder().decode(splitToken[0]));
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode headerNode;
+        try{
+            headerNode = objectMapper.readTree(headerJson); // JSON으로 변환
+        } catch (Exception e){
+            throw new BaseException(GlobalErrorCode.TOKEN_HEADER_NOT_FOUND);
+        }
+        return headerNode.get("kid").asText(); // kid 반환
+    }
+
+    // 공개 키로 검증한 JWS 객체를 aud, iss 검증하고 페이로드 추출하고 페이로드 정보를 OIDCDecodedPayload로 반환
+    public OIDCDecodePayload getOIDCTokenPayload(Jws<Claims> jws, String iss, String aud){
+        Claims payload = validateClaims(jws, iss, aud);
+        return new OIDCDecodePayload(
+                payload.getIssuer(),
+                payload.getAudience().toString(),
+                payload.getSubject(),
+                payload.get("email", String.class),
+                payload.get("name", String.class)
+        );
+    }
+
+    // 클레임을 검증하는 메서드
+    public Claims validateClaims(Jws<Claims> jws, String iss, String aud) {
+        Claims claims = jws.getPayload();
+        if(!claims.getIssuer().equals(iss) || !claims.getAudience().contains(aud)){
+            throw new BaseException(GlobalErrorCode.INVALID_TOKEN);
+        }
+        return claims;
+    }
+
+    // RSA 공개키를 사용하여 JWT을 파싱하여 서명 검증 후, 유효하면, 클레임을 포함한 JWS 객체를 반환함 : 서명 검증
+    public Jws<Claims> getOIDCTokenJws(String token, String modulus, String exponent) {
+        try {
+            log.debug("Verifying JWT token with RSA public key: {}", token);
+            return Jwts.parser()
+                    .verifyWith(getRSAPublicKey(modulus, exponent)) // modulus, exponent: 공개키 구성 요소
+                    .build()
+                    .parseSignedClaims(token); // 공개키로 검증 후, 유효하면 페이로드와 서명 정보 반환
+        } catch (ExpiredJwtException e) {
+            log.error("Token has expired: {}", token);
+            throw new BaseException(GlobalErrorCode.EXPIRED_TOKEN);
+        } catch (Exception e) {
+            log.error("Error verifying token: {}, Exception: {}", token, e.getMessage(), e);
+            throw new BaseException(GlobalErrorCode.INVALID_SIGNATURE_TOKEN);
+        }
+    }
+
+    // RSA 공개키를 생성하는 메서드
+    private PublicKey getRSAPublicKey(String modulus, String exponent)
+            throws NoSuchAlgorithmException, InvalidKeySpecException {
+        log.debug("Generating RSA public key from modulus and exponent.");
+        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+        byte[] decodeN = Base64.getUrlDecoder().decode(modulus); // Base64 URL 디코딩
+        byte[] decodeE = Base64.getUrlDecoder().decode(exponent); // Base64 URL 디코딩
+        BigInteger n = new BigInteger(1, decodeN);
+        BigInteger e = new BigInteger(1, decodeE);
+
+        RSAPublicKeySpec keySpec = new RSAPublicKeySpec(n, e);
+        PublicKey publicKey = keyFactory.generatePublic(keySpec);
+        log.debug("Generated RSA public key: {}", publicKey);
+        return publicKey;
+    }
+}

--- a/src/main/java/com/haertz/be/common/jwt/JwtProvider.java
+++ b/src/main/java/com/haertz/be/common/jwt/JwtProvider.java
@@ -1,0 +1,93 @@
+package com.haertz.be.common.jwt;
+
+import com.haertz.be.common.exception.GlobalErrorCode;
+import com.haertz.be.common.exception.base.BaseException;
+import com.haertz.be.common.jwt.dto.DecodedJwtToken;
+import com.haertz.be.common.jwt.properties.JwtProperties;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+import static com.haertz.be.common.constant.StaticValue.ACCESS_TOKEN;
+import static com.haertz.be.common.constant.StaticValue.REFRESH_TOKEN;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtProvider {
+    private final JwtProperties jwtProperties;
+
+    public SecretKey getSecretKey() {
+        return Keys.hmacShaKeyFor(jwtProperties.getSecretKey().getBytes());
+    }
+
+    private Jws<Claims> parseClaims(String token) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(getSecretKey())
+                    .build()
+                    .parseSignedClaims(token);
+        } catch (ExpiredJwtException e) {
+            throw new BaseException(GlobalErrorCode.EXPIRED_TOKEN);
+        } catch (Exception e) {
+            throw new BaseException(GlobalErrorCode.INVALID_TOKEN);
+        }
+    }
+
+    //access , refresh token 만드는 함수
+    public String generateToken(Long userId, String role, String type) {
+        Date now = new Date();
+        int exp = 0;
+        if (type.equalsIgnoreCase(ACCESS_TOKEN)) {
+            exp = jwtProperties.getAccessTokenExp();
+        } else if (type.equalsIgnoreCase(REFRESH_TOKEN)) {
+            exp = jwtProperties.getRefreshTokenExp();
+        }
+
+        return Jwts.builder()
+                .issuer("RouteFinders")
+                .subject(userId.toString())
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + exp))
+                .claim("type", type)
+                .claim("role", role)
+                .signWith(getSecretKey())
+                .compact();
+
+    }
+
+    // 토큰 검증하는 함수
+    public boolean validateToken(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    //토큰 decoded 하는 함수
+    public DecodedJwtToken decodedToken(String token, String type) {
+        Claims claims = parseClaims(token).getPayload();
+        checkType(claims, type);
+        return DecodedJwtToken.builder()
+                .userId(Long.valueOf(claims.getSubject()))
+                .role(String.valueOf(claims.get("role")))
+                .type(String.valueOf(claims.get("type")))
+                .build();
+    }
+
+    private void checkType(Claims claims, String type) {
+        if (type.equalsIgnoreCase(String.valueOf(claims.get("type")))) return;
+        else throw new BaseException(GlobalErrorCode.NOT_MATCHED_TOKEN_TYPE);
+    }
+
+}

--- a/src/main/java/com/haertz/be/common/jwt/OAuthOIDCProcessor.java
+++ b/src/main/java/com/haertz/be/common/jwt/OAuthOIDCProcessor.java
@@ -1,0 +1,30 @@
+package com.haertz.be.common.jwt;
+
+import com.haertz.be.common.exception.GlobalErrorCode;
+import com.haertz.be.common.exception.base.BaseException;
+import com.haertz.be.common.feign.oidc.OIDCPublicKeyDto;
+import com.haertz.be.common.feign.oidc.OIDCPublicKeysResponse;
+import com.haertz.be.common.jwt.dto.OIDCDecodePayload;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OAuthOIDCProcessor {
+    private final JwtOIDCProvider jwtOIDCProvider;
+
+    /* ID 토큰 헤더에서 kid 추출하고, oidcPublicKeysResponse에서 kid와 일치하는 공개키 찾는다
+    서명 검증 후, iss와 aud 검증 후, 페이로드를 디코딩함 */
+    public OIDCDecodePayload getPayloadFromIdToken(String token, String iss, String aud, OIDCPublicKeysResponse oidcPublicKeysResponse) {
+        String kid = jwtOIDCProvider.getKidFromToken(token); // 서명 검증을 위해 kid 추출
+
+        OIDCPublicKeyDto oidcPublicKeyDto = oidcPublicKeysResponse.getKeys().stream()// oidcPublicKeysResponse에서 kid 와 일치하는 공개키 찾음
+                .filter(o -> o.getKid().equals(kid))
+                .findFirst()
+                .orElseThrow(() -> new BaseException(GlobalErrorCode.INVALID_TOKEN));
+        Jws<Claims> sigVerifiedJws = jwtOIDCProvider.getOIDCTokenJws(token, oidcPublicKeyDto.getN(), oidcPublicKeyDto.getE());
+        return  jwtOIDCProvider.getOIDCTokenPayload(sigVerifiedJws, iss, aud);// 서명 검증 받은 Jws 객체를 iss와 aud 검증하고 페이로드 디코딩
+    }
+}

--- a/src/main/java/com/haertz/be/common/jwt/dto/DecodedJwtToken.java
+++ b/src/main/java/com/haertz/be/common/jwt/dto/DecodedJwtToken.java
@@ -1,0 +1,14 @@
+package com.haertz.be.common.jwt.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+@Builder
+public class DecodedJwtToken {
+    private Long userId;
+    private String role;
+    private String type;
+}

--- a/src/main/java/com/haertz/be/common/jwt/dto/OIDCDecodePayload.java
+++ b/src/main/java/com/haertz/be/common/jwt/dto/OIDCDecodePayload.java
@@ -1,0 +1,15 @@
+package com.haertz.be.common.jwt.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+// id token을 decoded 했을 때 나오는 필드들
+public class OIDCDecodePayload {
+    private String iss; // 발급기관 식별자
+    private String aud; // 애플리케이션 클라이언트 ID
+    private String sub; // 사용자 ID
+    private String email; // 사용자 이메일
+    private String name; // 사용자 이름
+}

--- a/src/main/java/com/haertz/be/common/jwt/dto/UserInfoFromIdToken.java
+++ b/src/main/java/com/haertz/be/common/jwt/dto/UserInfoFromIdToken.java
@@ -1,0 +1,13 @@
+package com.haertz.be.common.jwt.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class UserInfoFromIdToken {
+    private String name;
+    private String email;
+}

--- a/src/main/java/com/haertz/be/common/jwt/filter/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/haertz/be/common/jwt/filter/CustomAccessDeniedHandler.java
@@ -1,0 +1,29 @@
+package com.haertz.be.common.jwt.filter;
+
+import com.haertz.be.common.exception.GlobalErrorCode;
+import com.haertz.be.common.exception.base.BaseException;
+import com.haertz.be.common.jwt.FilterExceptionProcessor;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+// Spring Security에서 사용자가 접근 권한이 없을 때 발생하는 AccessDeniedException을 처리하기 위한 커스텀 핸들러
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final FilterExceptionProcessor filterExceptionProcessor;
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException)
+            throws IOException {
+        filterExceptionProcessor.excute(response, new BaseException(GlobalErrorCode.ACCESS_DENIED_REQUEST));
+    }
+
+}

--- a/src/main/java/com/haertz/be/common/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/haertz/be/common/jwt/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,70 @@
+package com.haertz.be.common.jwt.filter;
+
+import com.haertz.be.auth.service.TokenBlacklistRedisService;
+import com.haertz.be.common.exception.base.BaseException;
+import com.haertz.be.common.jwt.FilterExceptionProcessor;
+import com.haertz.be.common.jwt.JwtProvider;
+import com.haertz.be.common.jwt.dto.DecodedJwtToken;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+    private final FilterExceptionProcessor filterExceptionProcessor;
+    private final TokenBlacklistRedisService tokenBlacklistRedisService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
+        try {
+            String token = resolveToken(request); // 토큰 추출함
+            if (token != null) {
+                tokenBlacklistRedisService.checkTokenBlacklisted(token); // 블랙리스트 accessToken 검증
+                if (jwtProvider.validateToken(token)) { // 토큰 유효성 검사
+                    Authentication authentication = getAuthentication(token); // 인증 객체 생성
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
+            }
+            chain.doFilter(request, response); // 다음 필터로 요청 전달
+        } catch (BaseException e) {
+            filterExceptionProcessor.excute(response, e);
+        }
+    }
+
+
+    private Authentication getAuthentication(String token) {
+        DecodedJwtToken decodedJwtToken = jwtProvider.decodedToken(token,"accessToken");
+        Long userId = decodedJwtToken.getUserId();
+        String role = decodedJwtToken.getRole();
+
+        List<SimpleGrantedAuthority> authorities = new ArrayList<>(); // 사용자의 권한 목록을 생성합니다.
+        authorities.add(new SimpleGrantedAuthority("ROLE_" + role));
+        // 인증된 사용자 정보를 SecurityContext에 설정합니다.
+        return new UsernamePasswordAuthenticationToken(userId, null, authorities);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/com/haertz/be/common/jwt/properties/JwtProperties.java
+++ b/src/main/java/com/haertz/be/common/jwt/properties/JwtProperties.java
@@ -1,0 +1,14 @@
+package com.haertz.be.common.jwt.properties;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@AllArgsConstructor
+@ConfigurationProperties("jwt")
+public class JwtProperties {
+    private String secretKey;
+    private int accessTokenExp;
+    private int refreshTokenExp;
+}

--- a/src/main/java/com/haertz/be/common/jwt/properties/OauthProperties.java
+++ b/src/main/java/com/haertz/be/common/jwt/properties/OauthProperties.java
@@ -1,0 +1,44 @@
+package com.haertz.be.common.jwt.properties;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@AllArgsConstructor
+@ConfigurationProperties(prefix = "spring.security.oauth2.client.registration")
+public class OauthProperties {
+    private OauthSecret google;
+
+    public String getGoogleClientId() {
+        return google.getClientId();
+    }
+
+    public String getGoogleClientSecret() {
+        return google.getClientSecret();
+    }
+
+    public String getGoogleClientName() {
+        return google.getClientName();
+    }
+
+    public String getGoogleRedirectUri() {
+        return google.getRedirectUri();
+    }
+
+    public String getGoogleScope(){
+        return google.getScope();
+    }
+
+    @Getter
+    @Setter
+    public static class OauthSecret {
+        private String scope;
+        private String clientId;
+        private String clientSecret;
+        private String clientName;
+        private String redirectUri;
+    }
+
+}

--- a/src/main/java/com/haertz/be/common/redis/BaseRedisRepository.java
+++ b/src/main/java/com/haertz/be/common/redis/BaseRedisRepository.java
@@ -1,0 +1,56 @@
+package com.haertz.be.common.redis;
+
+import com.haertz.be.common.exception.GlobalErrorCode;
+import com.haertz.be.common.exception.base.BaseException;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+// redis 기본 기능을 제공하는 추상 클래스
+public abstract class BaseRedisRepository<T> {
+    protected RedisTemplate<String, T> redisTemplate;
+    protected String prefix;
+
+    public void save(Long id, T t) {
+        try {
+            redisTemplate.opsForValue().set(generateKeyFromId(id), t); // T 객체를 그대로 저장 (RedisTemplate이 직렬화 처리)
+        } catch (Exception e) {
+            throw new BaseException(GlobalErrorCode.REDIS_SAVE_FAILED);
+        }
+    }
+
+    // 만료 시간 포함한 save 함수
+    public void saveWithExpiration(String keyName , T t, long expirationTime){
+        try{
+            redisTemplate.opsForValue().set(keyName,t,expirationTime, TimeUnit.MILLISECONDS);
+        } catch (Exception e){
+            throw new BaseException(GlobalErrorCode.REDIS_SAVE_FAILED);
+        }
+    }
+
+    public Optional<T> findById(Long id) {
+        T value = redisTemplate.opsForValue().get(generateKeyFromId(id));
+        return Optional.ofNullable(value);
+    }
+
+    public boolean hasKey(String keyName){
+        return Boolean.TRUE.equals(redisTemplate.hasKey(generateKey(keyName)));
+    }
+
+    public void deleteByKey(String key) {
+        try {
+            redisTemplate.delete(key);
+        } catch (Exception e) {
+            throw new BaseException(GlobalErrorCode.REDIS_DELETE_FAILED);
+        }
+    }
+
+    public String generateKeyFromId(Long id) {
+        return prefix + id.toString();
+    }
+
+    public String generateKey(String keyName){
+        return prefix + keyName;
+    }
+}

--- a/src/main/java/com/haertz/be/common/response/BaseResponse.java
+++ b/src/main/java/com/haertz/be/common/response/BaseResponse.java
@@ -1,0 +1,33 @@
+package com.haertz.be.common.response;
+
+import com.haertz.be.common.exception.base.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Getter
+@ToString
+@RequiredArgsConstructor
+public class BaseResponse {
+
+    private final String timestamp = LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME);
+    private final Boolean isSuccess;
+    private final String code;
+    private final String message;
+
+    public static BaseResponse of(Boolean isSuccess, BaseErrorCode code){
+        return new BaseResponse(isSuccess, code.getCode(), code.getMessage());
+    }
+
+    public static BaseResponse of(Boolean isSuccess, String code, String message){
+        return new BaseResponse(isSuccess, code, message);
+    }
+
+    public static BaseResponse success(){
+        return new BaseResponse(true, "200", "호출에 성공하셨습니다");
+    }
+
+}

--- a/src/main/java/com/haertz/be/common/response/ErrorResponse.java
+++ b/src/main/java/com/haertz/be/common/response/ErrorResponse.java
@@ -1,0 +1,38 @@
+package com.haertz.be.common.response;
+
+import com.haertz.be.common.exception.base.BaseErrorCode;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class ErrorResponse extends BaseResponse {
+    private final int httpStatus;
+
+    @Builder
+    public ErrorResponse(boolean success, String code, String message, int httpStatus) {
+        super(success, code, message);
+        this.httpStatus = httpStatus;
+    }
+
+    // errorCode를 이용해 ErrorResponse 생성
+    public static ErrorResponse fromErrorCode(BaseErrorCode errorCode) {
+        return ErrorResponse.builder()
+                .success(false)
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .httpStatus(errorCode.getHttpStatus())
+                .build();
+    }
+
+    // errorCode와 커스텀 메시지를 이용해 ErrorResponse 생성
+    public static ErrorResponse fromErrorCodeWithCustomMessage(BaseErrorCode errorCode, String customMessage) {
+        return ErrorResponse.builder()
+                .success(false)
+                .code(errorCode.getCode())
+                .message(customMessage)  // 커스텀 메시지를 사용
+                .httpStatus(errorCode.getHttpStatus())
+                .build();
+    }
+}

--- a/src/main/java/com/haertz/be/common/response/SuccessResponse.java
+++ b/src/main/java/com/haertz/be/common/response/SuccessResponse.java
@@ -1,0 +1,28 @@
+package com.haertz.be.common.response;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class SuccessResponse<T> extends BaseResponse {
+
+    private final T data;
+
+    public SuccessResponse(T data, String code){
+        super(true, code, "호출에 성공하셨습니다.");
+        this.data = data;
+    }
+
+    public static <T> SuccessResponse<T> of(T data){
+        return new SuccessResponse<>(data, "200");
+    }
+
+    public static <T> SuccessResponse<T> empty(){
+        return new SuccessResponse<>(null, "200");
+    }
+
+    public static <T> SuccessResponse<T> created(){
+        return new SuccessResponse<>(null, "201");
+    }
+}

--- a/src/main/java/com/haertz/be/common/utils/AuthenticatedUserUtils.java
+++ b/src/main/java/com/haertz/be/common/utils/AuthenticatedUserUtils.java
@@ -1,0 +1,20 @@
+package com.haertz.be.common.utils;
+
+import com.haertz.be.auth.adaptor.UserAdaptor;
+import com.haertz.be.auth.entity.User;
+import com.haertz.be.common.config.security.SecurityUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AuthenticatedUserUtils {
+    private final UserAdaptor userAdaptor;
+
+    public Long getCurrentUserId(){
+        return SecurityUtils.getCurrentUserId();
+    }
+    public User getCurrentUser(){
+        return userAdaptor.findById(getCurrentUserId());
+    }
+}

--- a/src/main/java/com/haertz/be/common/utils/TokenUtils.java
+++ b/src/main/java/com/haertz/be/common/utils/TokenUtils.java
@@ -1,0 +1,15 @@
+package com.haertz.be.common.utils;
+
+import com.haertz.be.common.exception.GlobalErrorCode;
+import com.haertz.be.common.exception.base.BaseException;
+import jakarta.servlet.http.HttpServletRequest;
+
+public class TokenUtils {
+    public static String resolveToken(HttpServletRequest request) {
+        String header = request.getHeader("Authorization");
+        if (header != null && header.startsWith("Bearer ")) {
+            return header.substring(7); // "Bearer "
+        } else throw new BaseException(GlobalErrorCode.HEADER_VALUE_NOT_FOUND);
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=be

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,44 @@
+server:
+  port: 8080
+
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-name: haertz
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            redirect-uri: ${GOOGLE_REDIRECT_URI}
+            scope: ${GOOGLE_SCOPE}
+
+  config:
+    import: optional:file:.env[.properties]
+
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        naming:
+          physical-strategy: org.springframework.boot.orm.jpa.hibernate.SpringPhysicalNamingStrategy
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      password: ${REDIS_PASSWORD}
+      database: 1
+
+jwt:
+  secret-key: ${JWT_SECRET}
+  access-token-exp: ${JWT_ACCESS_EXP}
+  refresh-token-exp: ${JWT_REFRESH_EXP}


### PR DESCRIPTION
# PR

## PR 요약
- 구글 소셜 회원가입 API를 구현했습니다.
   -> 회원가입 시, 액세스 토큰은 바디로 반환하고, 리프레쉬 토큰은 쿠키로 반환합니다.
- 구글 소셜 로그인 API를 구현했습니다.
- 서비스 로그아웃 API를 구현했습니다.
- RefreshToken으로 AccessToken 재발급 받는 API 구현했습니다. 
- 로그아웃 시, 쿠키에서 RefreshToken 삭제 후, 레디스에 AccessToken 등록하도록 구현했습니다.
- 스웨거 설정했습니다. 

## 변경된 점
- @ControllerAdvice 어노테이션과 스웨거 라이브러리 충돌로 인해 스프링부트 3.3.2 로 변경



## 이슈 번호
resolve #1 