### PR TITLE
infra: 깃허브 액션으로 CI/CD 자동화 및 도커 설정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+      - name: checkout
         uses: actions/checkout@v3
 
       - name: Set up JDK 17
@@ -31,15 +32,15 @@ jobs:
 
       - name: Docker Image Build and Push
         run: |
-          docker build -t ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_SERVER }} .
-          docker push ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_SERVER }}
+          docker build -t ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_IMAGE }} .
+          docker push ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_IMAGE }}
 
       - name: Deploy to EC2
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.HOST }}
           username: ubuntu
-          key: ${{ secrets.KEY }}
+          key: ${{ secrets.SECRET_KEY }}
           script: |
             cd /home/ubuntu/ 
             
@@ -55,5 +56,5 @@ jobs:
             sudo docker rm $(sudo docker ps -qa) || true
             sudo docker image prune -af || true
             
-            sudo docker pull ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_SERVER }} 
+            sudo docker pull ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_IMAGE }} 
             docker-compose up -d --remove-orphans

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,59 @@
+on:
+  push:
+    branches: [ develop ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Build with Gradle
+        run: |
+          chmod +x ./gradlew 
+          ./gradlew bootJar
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Docker Image Build and Push
+        run: |
+          docker build -t ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_SERVER }} .
+          docker push ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_SERVER }}
+
+      - name: Deploy to EC2
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.HOST }}
+          username: ubuntu
+          key: ${{ secrets.KEY }}
+          script: |
+            cd /home/ubuntu/ 
+            
+            sudo touch .env  
+            echo "${{ secrets.ENV_VARS }}" | sudo tee .env > /dev/null 
+
+            sudo touch docker-compose.yml 
+             echo "${{ secrets.DOCKER_COMPOSE }}" | sudo tee docker-compose.yml > /dev/null
+
+            sudo chmod 666 /var/run/docker.sock 
+            
+            sudo docker stop $(sudo docker ps -q) || true
+            sudo docker rm $(sudo docker ps -qa) || true
+            sudo docker image prune -af || true
+            
+            sudo docker pull ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_SERVER }} 
+            docker-compose up -d --remove-orphans

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build/
 
 ### 8HERTZ ###
 **/.env
+**/docker-compose.yml
 
 ### STS ###
 .apt_generated

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ FROM openjdk:17-jdk-slim
 ARG JAR_FILE=/build/libs/*.jar
 COPY ${JAR_FILE} app.jar
 
-EXPOSE 8080
+EXPOSE 8443
 
 ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM openjdk:17-jdk-slim
+
+ARG JAR_FILE=/build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: 8080
+  port: 8443
 
 spring:
   security:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,7 +36,6 @@ spring:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
       password: ${REDIS_PASSWORD}
-      database: 1
 
 jwt:
   secret-key: ${JWT_SECRET}


### PR DESCRIPTION
# PR

## PR 요약
- 워크플로우를 작성하여 develop 브랜치에 push 했을 때 자동으로 배포하는 환경을 구성했습니다.
- docker-compose.yml 를 통해 redis, server 이미지를 정의했습니다.
- Dockerfile을 작성했습니다.

## 변경된 점
changes

## 이슈 번호
issue number #5