### PR TITLE
feat: 디자이너 엔티티 필드 수정 및 디자이너미팅링크 엔티티 생성

### DIFF
--- a/src/main/java/com/haertz/be/designer/entity/Designer.java
+++ b/src/main/java/com/haertz/be/designer/entity/Designer.java
@@ -19,4 +19,8 @@ public class Designer extends BaseTimeEntity {
 
     @Column(name = "designer_name")
     private String designerName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "meeting_mode", nullable = false)
+    private MeetingMode meetingMode;
 }

--- a/src/main/java/com/haertz/be/designer/entity/DesignerMeetingLink.java
+++ b/src/main/java/com/haertz/be/designer/entity/DesignerMeetingLink.java
@@ -1,0 +1,41 @@
+package com.haertz.be.designer.entity;
+
+import com.haertz.be.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalTime;
+
+@Entity
+@Table(name = "designer_meeting_link", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"designer_id", "start_time"})
+})
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DesignerMeetingLink extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 해당 미팅 링크가 어떤 디자이너에 속하는지
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "designer_id", nullable = false)
+    private Designer designer;
+
+    @Column(name = "start_time", nullable = false)
+    private LocalTime startTime;
+
+    // 미팅 종료 시간 (예: 11:00)
+    @Column(name = "end_time", nullable = false)
+    private LocalTime endTime;
+
+    // 해당 시간 슬롯에 할당된 구글 미팅 링크 (대면 전용 디자이너는 null)
+    @Column(name = "google_meeting_link", unique = true)
+    private String googleMeetingLink;
+}

--- a/src/main/java/com/haertz/be/designer/entity/MeetingMode.java
+++ b/src/main/java/com/haertz/be/designer/entity/MeetingMode.java
@@ -1,0 +1,7 @@
+package com.haertz.be.designer.entity;
+
+public enum MeetingMode {
+    REMOTE,        // 비대면만 가능한 경우
+    FACE_TO_FACE,  // 대면만 가능한 경우
+    BOTH           // 대면, 비대면 모두 가능한 경우
+}


### PR DESCRIPTION
# PR

## PR 요약
비대면 가능 디자이너에 대해 디자이너 미팅링크를 매핑시키기 위해 디자이너 엔티티에 상담 모드 필드를 추가하고, 디자이너 미팅링크 엔티티를 생성하였습니다. 

## 변경된 점
- 디자이너 엔티티에 meetingMode 필드를 추가
- 디자이너미팅링크 엔티티와 디자이너 엔티티를 다대일 관계 설정 후, 미팅링크 엔티티를 구성하였습니다. 

## 이슈 번호
issue number #31 