### PR TITLE
feat: 디자이너 별 예약 가능 날짜 및 시간 반환 API 구현

### DIFF
--- a/src/main/java/com/haertz/be/booking/adaptor/DesignerScheduleAdaptor.java
+++ b/src/main/java/com/haertz/be/booking/adaptor/DesignerScheduleAdaptor.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 
 @Adaptor
 @RequiredArgsConstructor
@@ -43,5 +44,13 @@ public class DesignerScheduleAdaptor {
     }
     public void deleteById(Long designerScheduleId) {
         designerScheduleRepository.deleteById(designerScheduleId);
+    }
+
+    public List<LocalDate> findFullyBookedDates(Long designerId, LocalDate startDate, LocalDate endDate, int maxSlots) {
+        return designerScheduleRepository.findFullyBookedDates(designerId, startDate, endDate, maxSlots);
+    }
+
+    public List<LocalTime> findBookedTimes(Long designerId, LocalDate bookingDate) {
+        return designerScheduleRepository.findBookedTimes(designerId, bookingDate);
     }
 }

--- a/src/main/java/com/haertz/be/booking/constant/AvailableTimeSlots.java
+++ b/src/main/java/com/haertz/be/booking/constant/AvailableTimeSlots.java
@@ -1,0 +1,24 @@
+package com.haertz.be.booking.constant;
+
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class AvailableTimeSlots {
+    public static final List<LocalTime> TIME_SLOTS;
+
+    static {
+        List<LocalTime> slots = new ArrayList<>();
+        LocalTime startTime = LocalTime.of(10, 0);
+        LocalTime endTime = LocalTime.of(19, 30);
+
+        while (startTime.isBefore(endTime.plusMinutes(1))) {
+            slots.add(startTime);
+            startTime = startTime.plusMinutes(30);
+
+        }
+
+        TIME_SLOTS = Collections.unmodifiableList(slots);
+    }
+}

--- a/src/main/java/com/haertz/be/booking/controller/BookingController.java
+++ b/src/main/java/com/haertz/be/booking/controller/BookingController.java
@@ -2,17 +2,22 @@ package com.haertz.be.booking.controller;
 
 import com.haertz.be.booking.dto.request.BookingInfoRequest;
 import com.haertz.be.booking.dto.response.BookingResponse;
-import com.haertz.be.booking.service.BookingDomainService;
 import com.haertz.be.booking.usecase.BookUseCase;
+import com.haertz.be.booking.usecase.GetAvailableDatesUseCase;
+import com.haertz.be.booking.usecase.GetAvailableTimesUseCase;
 import com.haertz.be.common.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,11 +25,27 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/booking")
 public class BookingController {
     private final BookUseCase bookUseCase;
+    private final GetAvailableDatesUseCase getAvailableDatesUseCase;
+    private final GetAvailableTimesUseCase getAvailableTimesUseCase;
 
     @Operation(summary = "헤어 컨설팅 일정 예약을 요청합니다.")
     @PostMapping
-    public SuccessResponse<BookingResponse> book(@RequestBody @Valid BookingInfoRequest bookingInfoRequest){
+    public SuccessResponse<BookingResponse> book(@RequestBody @Valid BookingInfoRequest bookingInfoRequest) {
         BookingResponse bookingResponse = bookUseCase.execute(bookingInfoRequest);
         return SuccessResponse.of(bookingResponse);
+    }
+
+    @Operation(summary = "해당 디자이너의 3개월 내 예약 가능 날짜를 조회합니다.")
+    @GetMapping("/available-dates")
+    public SuccessResponse<Map<String, List<LocalDate>>> getAvailableDates(@RequestParam @Min(1) Long designerId) {
+        List<LocalDate> availableDates = getAvailableDatesUseCase.execute(designerId);
+        return SuccessResponse.of(Collections.singletonMap("예약 가능 날짜 리스트: ", availableDates));
+    }
+
+    @Operation(summary = "해당 디자이너의 선택한 날짜의 예약 가능 시간을 조회합니다.")
+    @GetMapping("/available-times")
+    public SuccessResponse<Map<String, List<LocalTime>>> getAvailableTimes(@RequestParam @Min(1) Long designerId, @RequestParam LocalDate bookingDate) {
+        List<LocalTime> availableTimes = getAvailableTimesUseCase.execute(designerId, bookingDate);
+        return SuccessResponse.of(Collections.singletonMap("예약 가능 시간 리스트: ", availableTimes));
     }
 }

--- a/src/main/java/com/haertz/be/booking/exception/BookingErrorCode.java
+++ b/src/main/java/com/haertz/be/booking/exception/BookingErrorCode.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum BookingErrorCode implements BaseErrorCode {
-    INVALID_BOOKING_DATE(400, "BOOKING_400_1", "예약 날짜는 오늘 이후여야 합니다."),
+    INVALID_BOOKING_DATE(400, "BOOKING_400_1", "유효한 예약 날짜가 아닙니다. [예약 가능 범위: 오늘 ~ 3개월 후 말일]"),
     INVALID_BOOKING_TIME(400, "BOOKING_400_2", "예약 시간은 현재 시간 이후여야 합니다."),
     INVALID_TIME_FORMAT(400, "BOOKING_400_3", "예약 시간은 30분 단위여야 합니다."),
     OUT_OF_AVAILABLE_TIME_RANGE(400, "BOOKING_400_4", "예약 가능한 시간 범위를 벗어났습니다."),

--- a/src/main/java/com/haertz/be/booking/repository/DesignerScheduleRepository.java
+++ b/src/main/java/com/haertz/be/booking/repository/DesignerScheduleRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 
 public interface DesignerScheduleRepository extends JpaRepository<DesignerSchedule, Long> {
     @Query("SELECT COUNT(ds) > 0 FROM DesignerSchedule ds " +
@@ -23,5 +24,20 @@ public interface DesignerScheduleRepository extends JpaRepository<DesignerSchedu
                                  @Param("bookingDate") LocalDate bookingDate,
                                  @Param("bookingTime") LocalTime bookingTime);
 
+    @Query("SELECT ds.bookingDate FROM DesignerSchedule ds " +
+            "WHERE ds.designerId = :designerId " +
+            "AND ds.bookingDate BETWEEN :startDate AND :endDate " +
+            "GROUP BY ds.bookingDate " +
+            "HAVING COUNT(ds) >= :maxSlots")
+    List<LocalDate> findFullyBookedDates(@Param("designerId") Long designerId,
+                                         @Param("startDate") LocalDate startDate,
+                                         @Param("endDate") LocalDate endDate,
+                                         @Param("maxSlots") long maxSlots);
 
+    // 해당 날짜의 예약된 시간 조회
+    @Query("SELECT ds.bookingTime FROM DesignerSchedule ds " +
+            "WHERE ds.designerId = :designerId " +
+            "AND ds.bookingDate = :bookingDate")
+    List<LocalTime> findBookedTimes(@Param("designerId") Long designerId,
+                                    @Param("bookingDate") LocalDate bookingDate);
 }

--- a/src/main/java/com/haertz/be/booking/service/DesignerScheduleDomainService.java
+++ b/src/main/java/com/haertz/be/booking/service/DesignerScheduleDomainService.java
@@ -1,8 +1,8 @@
 package com.haertz.be.booking.service;
 
 import com.haertz.be.booking.adaptor.DesignerScheduleAdaptor;
+import com.haertz.be.booking.constant.AvailableTimeSlots;
 import com.haertz.be.booking.converter.BookingConverter;
-import com.haertz.be.booking.dto.request.BookingInfoRequest;
 import com.haertz.be.booking.dto.request.PreBookingRequest;
 import com.haertz.be.booking.entity.DesignerSchedule;
 import com.haertz.be.booking.exception.BookingErrorCode;
@@ -15,6 +15,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.haertz.be.booking.constant.AvailableTimeSlots.TIME_SLOTS;
+import static com.haertz.be.common.constant.StaticValue.MAX_SLOTS;
 
 @Service
 @RequiredArgsConstructor
@@ -77,7 +83,53 @@ public class DesignerScheduleDomainService {
         }
 
     }
+    @Transactional(readOnly = true)
+    public List<LocalDate> getAvailableDates(Long designerId){
+        LocalDate today = LocalDate.now();
+        LocalDate endDate = YearMonth.from(today.plusMonths(3)).atEndOfMonth();
 
+        List<LocalDate> allDates = today.datesUntil(endDate.plusDays(1))
+                .toList();
 
+        List<LocalDate> fullyBookedDates = designerScheduleAdaptor.findFullyBookedDates(designerId, today, endDate, MAX_SLOTS);
+
+        return allDates.stream()
+                .filter(date -> !fullyBookedDates.contains(date) || (date.equals(today) && hasAvailableTimesToday(designerId, today)))
+                .collect(Collectors.toList());
+    }
+
+    // 오늘 날짜에서 현재 시간 이후 가능한 시간 있는지 확인
+    private boolean hasAvailableTimesToday(Long designerId, LocalDate today) {
+        List<LocalTime> bookedTimes = designerScheduleAdaptor.findBookedTimes(designerId, today);
+
+        LocalTime now = LocalTime.now().withSecond(0).withNano(0);
+        return TIME_SLOTS.stream()
+                .anyMatch(time -> time.isAfter(now) && !bookedTimes.contains(time));
+    }
+
+    // 해당 날짜에서 예약 가능 시간 반환
+    public List<LocalTime> getAvailableTimes(Long designerId, LocalDate bookingDate) {
+
+        LocalDate today = LocalDate.now();
+        LocalDate endDate = YearMonth.from(today.plusMonths(3)).atEndOfMonth();
+
+        if (bookingDate == null || bookingDate.isBefore(today) || bookingDate.isAfter(endDate)) {
+            throw new BaseException(BookingErrorCode.INVALID_BOOKING_DATE);
+        }
+
+        List<LocalTime> bookedTimes = designerScheduleAdaptor.findBookedTimes(designerId, bookingDate);
+        List<LocalTime> availableTimes = AvailableTimeSlots.TIME_SLOTS;
+
+        if (bookingDate.equals(LocalDate.now())) {
+            LocalTime now = LocalTime.now().withSecond(0).withNano(0);
+            availableTimes = availableTimes.stream()
+                    .filter(time -> time.isAfter(now))
+                    .toList();
+        }
+
+        return availableTimes.stream()
+                .filter(time -> !bookedTimes.contains(time))
+                .collect(Collectors.toList());
+    }
 
 }

--- a/src/main/java/com/haertz/be/booking/service/DesignerScheduleDomainService.java
+++ b/src/main/java/com/haertz/be/booking/service/DesignerScheduleDomainService.java
@@ -94,9 +94,18 @@ public class DesignerScheduleDomainService {
         List<LocalDate> fullyBookedDates = designerScheduleAdaptor.findFullyBookedDates(designerId, today, endDate, MAX_SLOTS);
 
         return allDates.stream()
-                .filter(date -> !fullyBookedDates.contains(date) || (date.equals(today) && hasAvailableTimesToday(designerId, today)))
+                .filter(date -> {
+                    if (date.equals(today) && LocalTime.now().isAfter(LocalTime.of(19, 30))) {
+                        return false;
+                    }
+                    if (date.equals(today)) {
+                        return hasAvailableTimesToday(designerId, today);
+                    }
+                    return !fullyBookedDates.contains(date);
+                })
                 .collect(Collectors.toList());
     }
+
 
     // 오늘 날짜에서 현재 시간 이후 가능한 시간 있는지 확인
     private boolean hasAvailableTimesToday(Long designerId, LocalDate today) {

--- a/src/main/java/com/haertz/be/booking/usecase/GetAvailableDatesUseCase.java
+++ b/src/main/java/com/haertz/be/booking/usecase/GetAvailableDatesUseCase.java
@@ -1,0 +1,18 @@
+package com.haertz.be.booking.usecase;
+
+import com.haertz.be.booking.service.DesignerScheduleDomainService;
+import com.haertz.be.common.annotation.UseCase;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@UseCase
+@RequiredArgsConstructor
+public class GetAvailableDatesUseCase {
+    private final DesignerScheduleDomainService designerScheduleDomainService ;
+
+    public List<LocalDate> execute(Long designerId){
+        return designerScheduleDomainService.getAvailableDates(designerId);
+    }
+}

--- a/src/main/java/com/haertz/be/booking/usecase/GetAvailableTimesUseCase.java
+++ b/src/main/java/com/haertz/be/booking/usecase/GetAvailableTimesUseCase.java
@@ -1,0 +1,20 @@
+package com.haertz.be.booking.usecase;
+
+import com.haertz.be.booking.service.DesignerScheduleDomainService;
+import com.haertz.be.common.annotation.UseCase;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+@UseCase
+@RequiredArgsConstructor
+public class GetAvailableTimesUseCase {
+    private final DesignerScheduleDomainService designerScheduleDomainService ;
+
+    public List<LocalTime> execute(Long designerId, LocalDate bookingDate) {
+        return designerScheduleDomainService.getAvailableTimes(designerId, bookingDate);
+    }
+
+}

--- a/src/main/java/com/haertz/be/common/constant/StaticValue.java
+++ b/src/main/java/com/haertz/be/common/constant/StaticValue.java
@@ -7,6 +7,6 @@ public class StaticValue {
     public static final String GOOGLE_GRANT_TYPE = "authorization_code";
     public static final String REFRESH_TOKEN_PREFIX = "refreshToken:";
     public static final String BLACKlIST_PREFIX = "blacklist:";
-    public static final int maxSlots = 20;
+    public static final int MAX_SLOTS = 20;
 
 }

--- a/src/main/java/com/haertz/be/common/constant/StaticValue.java
+++ b/src/main/java/com/haertz/be/common/constant/StaticValue.java
@@ -7,6 +7,6 @@ public class StaticValue {
     public static final String GOOGLE_GRANT_TYPE = "authorization_code";
     public static final String REFRESH_TOKEN_PREFIX = "refreshToken:";
     public static final String BLACKlIST_PREFIX = "blacklist:";
+    public static final int maxSlots = 20;
 
-    public static final String AVAILABLE_TIMES = "available_times:";
 }


### PR DESCRIPTION
# PR

## PR 요약
- 예약 가능한 날짜 및 시간 조회 API를 구현했습니다. 
- 예약 가능 날짜 API
  -> 오늘 ~ 해당 월 포함 3개월 이후 말일 까지 조회 가능합니다.
  -> 예약이 모두 찬 날은 반환하지 않습니다.
  -> 현재 시간이 19:30 이후 일 경우, 오늘 날짜 제외합니다. 

- 예약 가능 시간 조회 API
  -> 해당 디자이너의 예약 가능 시간을 반환합니다.
  -> 시간 범위는 오전 10:00 ~ 오후 7:30 입니다. 
  -> 현재 시점 이후만 반환됩니다. 

## 변경된 점

## 이슈 번호
resolved #38