### PR TITLE
feat: 유저, 예약, 디자이너스케줄, 결제 연결

### DIFF
--- a/src/main/java/com/haertz/be/payment/dto/BankTransferDto.java
+++ b/src/main/java/com/haertz/be/payment/dto/BankTransferDto.java
@@ -14,4 +14,5 @@ public class BankTransferDto {
     private String googleMeetingLink;
     private Date created_at;
     private PaymentStatus paymentstatus;
+    private String designerScheduleId;
 }

--- a/src/main/java/com/haertz/be/payment/dto/BankTransferRequestDto.java
+++ b/src/main/java/com/haertz/be/payment/dto/BankTransferRequestDto.java
@@ -8,7 +8,9 @@ import lombok.*;
 @NoArgsConstructor
 @ToString
 public class BankTransferRequestDto {
-    private String partner_order_id;
+    //private String partner_order_id;
+    //partner_order_id를 designerScheduleId로 변경
+    private String designerScheduleId;
     private String item_name;
     private String quantity;
     private String total_amount;

--- a/src/main/java/com/haertz/be/payment/dto/BankTransferRequestDto.java
+++ b/src/main/java/com/haertz/be/payment/dto/BankTransferRequestDto.java
@@ -9,7 +9,6 @@ import lombok.*;
 @ToString
 public class BankTransferRequestDto {
     private String partner_order_id;
-    private String partner_user_id;
     private String item_name;
     private String quantity;
     private String total_amount;

--- a/src/main/java/com/haertz/be/payment/dto/BankTransferRequestDto.java
+++ b/src/main/java/com/haertz/be/payment/dto/BankTransferRequestDto.java
@@ -2,6 +2,9 @@ package com.haertz.be.payment.dto;
 
 import lombok.*;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
+
 @Getter
 @Setter
 @AllArgsConstructor
@@ -10,7 +13,11 @@ import lombok.*;
 public class BankTransferRequestDto {
     //private String partner_order_id;
     //partner_order_id를 designerScheduleId로 변경
-    private String designerScheduleId;
+    //디자이너 스케줄 생성에 필요한 정보
+    private Long designerId;           // 예약 가능한 디자이너의 ID
+    private LocalDate bookingDate;     // 예약 날짜 (예: 2025-02-18)
+    private LocalTime bookingTime;     // 예약 시작 시간 (예: 10:00:00)
+
     private String item_name;
     private String quantity;
     private String total_amount;

--- a/src/main/java/com/haertz/be/payment/dto/KakaoPayApproveRequestDto.java
+++ b/src/main/java/com/haertz/be/payment/dto/KakaoPayApproveRequestDto.java
@@ -10,6 +10,5 @@ import lombok.*;
 public class KakaoPayApproveRequestDto {
     private String tid;
     private String partner_order_id;
-    private String partner_user_id;
     private String pg_token;
 }

--- a/src/main/java/com/haertz/be/payment/dto/KakaoPayApproveRequestDto.java
+++ b/src/main/java/com/haertz/be/payment/dto/KakaoPayApproveRequestDto.java
@@ -9,6 +9,7 @@ import lombok.*;
 @ToString
 public class KakaoPayApproveRequestDto {
     private String tid;
-    private String partner_order_id;
+    //private String partner_order_id;
+    private String designerScheduleId;
     private String pg_token;
 }

--- a/src/main/java/com/haertz/be/payment/dto/KakaoPayCancelRequestDto.java
+++ b/src/main/java/com/haertz/be/payment/dto/KakaoPayCancelRequestDto.java
@@ -10,7 +10,6 @@ import lombok.*;
 public class KakaoPayCancelRequestDto {
     private String tid;                  // 결제 승인 시 받은 결제 고유 번호
     private String partnerOrderId;       // 주문 번호
-    private String partnerUserId;        // 사용자 ID
     private int cancelAmount;
     private int cancelTaxFreeAmount;     // 취소할 비과세 금액 (예: 0)
 }

--- a/src/main/java/com/haertz/be/payment/dto/KakaoPayDTO.java
+++ b/src/main/java/com/haertz/be/payment/dto/KakaoPayDTO.java
@@ -16,4 +16,5 @@ public class KakaoPayDTO {
     private String next_redirect_mobile_url; //요청한 클라이언트가 모바일웹일 경우
     private String next_redirect_app_url;
     private Date created_at;
+    private String designerScheduleId;
 }

--- a/src/main/java/com/haertz/be/payment/dto/KakaoPayRequestDTO.java
+++ b/src/main/java/com/haertz/be/payment/dto/KakaoPayRequestDTO.java
@@ -11,7 +11,6 @@ public class KakaoPayRequestDTO {
     //예약을 결제 완료 시점에 디비에 저장하는경우
     //private int cid;
     private String partner_order_id; //기멩점 주문번호
-    private String partner_user_id; ////가맹점 회원 id
     private String item_name;
     private String quantity;
     private String total_amount;

--- a/src/main/java/com/haertz/be/payment/dto/KakaoPayRequestDTO.java
+++ b/src/main/java/com/haertz/be/payment/dto/KakaoPayRequestDTO.java
@@ -2,6 +2,9 @@ package com.haertz.be.payment.dto;
 
 import lombok.*;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
+
 @Getter
 @Setter
 @AllArgsConstructor
@@ -11,13 +14,16 @@ public class KakaoPayRequestDTO {
     //예약을 결제 완료 시점에 디비에 저장하는경우
     //private int cid;
     //private String partner_order_id; //기멩점 주문번호
-    private String designerScheduleId;
+    //private String designerScheduleId;
+
+    //디자이너 스케줄 생성에 필요한 정보
+    private Long designerId;           // 예약 가능한 디자이너의 ID
+    private LocalDate bookingDate;     // 예약 날짜 (예: 2025-02-18)
+    private LocalTime bookingTime;     // 예약 시작 시간 (예: 10:00:00)
+
+    //결제 관련 정보
     private String item_name;
     private String quantity;
     private String total_amount;
     private String tax_free_amount;
-
-    /* 예약을 미리 디비에 저장하는 경우
-    private Long reservationId; // 예약 ID (프론트에서 전달)
-     */
 }

--- a/src/main/java/com/haertz/be/payment/dto/KakaoPayRequestDTO.java
+++ b/src/main/java/com/haertz/be/payment/dto/KakaoPayRequestDTO.java
@@ -10,7 +10,8 @@ import lombok.*;
 public class KakaoPayRequestDTO {
     //예약을 결제 완료 시점에 디비에 저장하는경우
     //private int cid;
-    private String partner_order_id; //기멩점 주문번호
+    //private String partner_order_id; //기멩점 주문번호
+    private String designerScheduleId;
     private String item_name;
     private String quantity;
     private String total_amount;

--- a/src/main/java/com/haertz/be/payment/dto/PaymentSaveDto.java
+++ b/src/main/java/com/haertz/be/payment/dto/PaymentSaveDto.java
@@ -15,7 +15,7 @@ public class PaymentSaveDto {
     private Long userId;               // 회원 ID
     private Long reservationId;        // 예약 ID
     private BigDecimal totalAmount;    // 결제 금액
-    private String partnerOrderId;     // 외부 결제 서비스에서 사용하는 주문 ID
+    private String partnerOrderId;     // 외부 결제 서비스에서 사용하는 주문 ID-> 디자이너 스케쥴테이블에 있는 id
     private String paymentTransaction; // 결제 트랜잭션 ID
     private PaymentMethod paymentMethod;  // 결제 방식 (카카오페이, 계좌이체 등)
     private PaymentStatus paymentStatus;

--- a/src/main/java/com/haertz/be/payment/entity/Payment.java
+++ b/src/main/java/com/haertz/be/payment/entity/Payment.java
@@ -1,5 +1,6 @@
 package com.haertz.be.payment.entity;
 
+import com.haertz.be.booking.entity.Booking;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,11 +20,10 @@ public class Payment {
     @Column(name="payment_id") //DB에서 자동 생성되는 PK 값
     private Long paymentId;
 
-    /* Reservation entity생성후 변경
     @OneToOne(cascade = CascadeType.ALL)
-    @JoinColumn(name="reservation_id",referencedColumnName = "reservation_id")
-    private Reservation reservation
-    */
+    @JoinColumn(name="booking_id",referencedColumnName = "booking_id")
+    private Booking booking;
+
     @Column(nullable = false,name="user_id")
     private Long userId;  //카카오페이시 이걸 partner_user_id로 사용해도 됨?
 
@@ -41,7 +41,7 @@ public class Payment {
     @Column(nullable = false,name="payment_status")
     private PaymentStatus paymentStatus=PaymentStatus.PENDING;
 
-    @Column(name="partner_order_id") //외부 결제 서비스(카카오페이)에서 사용되는 주문 ID.
+    @Column(name="partner_order_id") //결제 건을 식별하는 외부 주문 번호 역할- >디자이너스케줄테이블의 아이디 사용
     private String partnerOrderId;
 
     @Column(name="payment_transaction") //카카오페이의 tid

--- a/src/main/java/com/haertz/be/payment/service/BankTransferService.java
+++ b/src/main/java/com/haertz/be/payment/service/BankTransferService.java
@@ -1,5 +1,6 @@
 package com.haertz.be.payment.service;
 
+import com.haertz.be.booking.service.DesignerScheduleDomainService;
 import com.haertz.be.common.exception.base.BaseException;
 import com.haertz.be.common.utils.AuthenticatedUserUtils;
 import com.haertz.be.googlemeet.service.GoogleMeetService;
@@ -23,6 +24,7 @@ public class BankTransferService {
     private final GoogleMeetService googleMeetService;
     private final temp temp;
     private final AuthenticatedUserUtils userUtils;
+    private final DesignerScheduleDomainService designerScheduleDomainService;
 
     public BankTransferDto banktransferrequest(BankTransferRequestDto requestDTO) {
         Long currentUserId = userUtils.getCurrentUserId();
@@ -77,7 +79,9 @@ public class BankTransferService {
             payment.setPaymentStatus(PaymentStatus.REFUNDED);
             temp.save(payment);
 
-            //디자이너 예약 확정 엔티티에서 관련 데이터 삭제(데이터들로 조회후 삭제 처리 구현)
+            //디자이너스케줄 확정 엔티티에서 관련 데이터 삭제(데이터들로 조회후 삭제 처리 구현)
+            Long designerScheduleId= Long.valueOf(payment.getPartnerOrderId());
+            designerScheduleDomainService.deleteScheduleAfterFailedPayment(designerScheduleId);
 
             //취소 완료 응답 dto 생성
             BankTransferCancelDto bankTransferCancelDto = new BankTransferCancelDto();

--- a/src/main/java/com/haertz/be/payment/service/BankTransferService.java
+++ b/src/main/java/com/haertz/be/payment/service/BankTransferService.java
@@ -1,6 +1,7 @@
 package com.haertz.be.payment.service;
 
 import com.haertz.be.common.exception.base.BaseException;
+import com.haertz.be.common.utils.AuthenticatedUserUtils;
 import com.haertz.be.googlemeet.service.GoogleMeetService;
 import com.haertz.be.payment.dto.*;
 import com.haertz.be.payment.entity.Payment;
@@ -21,8 +22,11 @@ public class BankTransferService {
     private final PaymentSaveService paymentSaveService;
     private final GoogleMeetService googleMeetService;
     private final temp temp;
+    private final AuthenticatedUserUtils userUtils;
 
     public BankTransferDto banktransferrequest(BankTransferRequestDto requestDTO) {
+        Long currentUserId = userUtils.getCurrentUserId();
+
         // 계좌이체 요청 정보가 유효한지 확인(나중에 예약관련된 검증도 추가)
         if (requestDTO == null  || requestDTO.getPartner_order_id() == null) {
             throw new BaseException(PaymentErrorCode.INVALID_PAYMENT_REQUEST);
@@ -32,7 +36,7 @@ public class BankTransferService {
             paymentSaveDto.setPaymentMethod(PaymentMethod.BANK_TRANSFER);
             paymentSaveDto.setPaymentDate(new Date());
             paymentSaveDto.setPaymentStatus(PaymentStatus.PENDING);
-            paymentSaveDto.setUserId(Long.valueOf(requestDTO.getPartner_user_id()));
+            paymentSaveDto.setUserId(currentUserId);
             paymentSaveDto.setTotalAmount(new BigDecimal(requestDTO.getTotal_amount()));
             log.info(paymentSaveDto.toString());
             Payment savedpayment=paymentSaveService.savePayment(paymentSaveDto);

--- a/src/main/java/com/haertz/be/payment/service/BankTransferService.java
+++ b/src/main/java/com/haertz/be/payment/service/BankTransferService.java
@@ -28,7 +28,7 @@ public class BankTransferService {
         Long currentUserId = userUtils.getCurrentUserId();
 
         // 계좌이체 요청 정보가 유효한지 확인(나중에 예약관련된 검증도 추가)
-        if (requestDTO == null  || requestDTO.getPartner_order_id() == null) {
+        if (requestDTO == null  || requestDTO.getDesignerScheduleId() == null) {
             throw new BaseException(PaymentErrorCode.INVALID_PAYMENT_REQUEST);
         }
         try {
@@ -38,6 +38,7 @@ public class BankTransferService {
             paymentSaveDto.setPaymentStatus(PaymentStatus.PENDING);
             paymentSaveDto.setUserId(currentUserId);
             paymentSaveDto.setTotalAmount(new BigDecimal(requestDTO.getTotal_amount()));
+            paymentSaveDto.setPartnerOrderId(requestDTO.getDesignerScheduleId());
             log.info(paymentSaveDto.toString());
             Payment savedpayment=paymentSaveService.savePayment(paymentSaveDto);
             /*
@@ -50,7 +51,6 @@ public class BankTransferService {
             log.info(googleMeetingLink.toString());
 
              */
-
             // 계좌이체 후 DTO 반환
             BankTransferDto bankTransferDto = new BankTransferDto();
             bankTransferDto.setPaymentId(savedpayment.getPaymentId());

--- a/src/main/java/com/haertz/be/payment/service/BankTransferService.java
+++ b/src/main/java/com/haertz/be/payment/service/BankTransferService.java
@@ -1,5 +1,6 @@
 package com.haertz.be.payment.service;
 
+import com.haertz.be.booking.dto.request.PreBookingRequest;
 import com.haertz.be.booking.service.DesignerScheduleDomainService;
 import com.haertz.be.common.exception.base.BaseException;
 import com.haertz.be.common.utils.AuthenticatedUserUtils;
@@ -30,17 +31,26 @@ public class BankTransferService {
         Long currentUserId = userUtils.getCurrentUserId();
 
         // 계좌이체 요청 정보가 유효한지 확인(나중에 예약관련된 검증도 추가)
-        if (requestDTO == null  || requestDTO.getDesignerScheduleId() == null) {
+        if (requestDTO == null) {
             throw new BaseException(PaymentErrorCode.INVALID_PAYMENT_REQUEST);
         }
         try {
+            //디자이너스케쥴(임시예약정보 생성해 다른 사용자가 예약하지 못하도록
+            PreBookingRequest preBooking = new PreBookingRequest(
+                    requestDTO.getDesignerId(),       // 디자이너 ID
+                    requestDTO.getBookingDate(),      // 예약 날짜
+                    requestDTO.getBookingTime()       // 예약 시간
+            );
+            // 임시 스케줄 생성 후 해당 스케줄의 ID를 반환받음.
+            Long tempScheduleId = designerScheduleDomainService.registerTempSchedule(currentUserId, preBooking);
+
             PaymentSaveDto paymentSaveDto = new PaymentSaveDto();
             paymentSaveDto.setPaymentMethod(PaymentMethod.BANK_TRANSFER);
             paymentSaveDto.setPaymentDate(new Date());
             paymentSaveDto.setPaymentStatus(PaymentStatus.PENDING);
             paymentSaveDto.setUserId(currentUserId);
             paymentSaveDto.setTotalAmount(new BigDecimal(requestDTO.getTotal_amount()));
-            paymentSaveDto.setPartnerOrderId(requestDTO.getDesignerScheduleId());
+            paymentSaveDto.setPartnerOrderId(String.valueOf(tempScheduleId));
             log.info(paymentSaveDto.toString());
             Payment savedpayment=paymentSaveService.savePayment(paymentSaveDto);
             /*
@@ -57,10 +67,13 @@ public class BankTransferService {
             BankTransferDto bankTransferDto = new BankTransferDto();
             bankTransferDto.setPaymentId(savedpayment.getPaymentId());
             bankTransferDto.setGoogleMeetingLink("구글미팅 링크 생성로직은 아직 구현 전..");
+            bankTransferDto.setDesignerScheduleId(String.valueOf(tempScheduleId));
             //String googlemeetlink=googleMeetingLink.getGoogleMeetingLink();
             //bankTransferDto.setGoogleMeetingLink(googlemeetlink);
             bankTransferDto.setCreated_at(new Date());
             bankTransferDto.setPaymentstatus(savedpayment.getPaymentStatus());
+            designerScheduleDomainService.confirmScheduleAfterPayment(tempScheduleId, PaymentStatus.PENDING);
+
             return bankTransferDto;
         } catch (Exception ex) {
             // 결제 처리 중 오류 발생 시

--- a/src/main/java/com/haertz/be/payment/service/KakaoPayService.java
+++ b/src/main/java/com/haertz/be/payment/service/KakaoPayService.java
@@ -79,6 +79,9 @@ public class KakaoPayService {
         try {
             kakaoPayDTO = restTemplate.postForObject(new URI(Host + "/v1/payment/ready"), body, KakaoPayDTO.class);
             log.info("카카오페이 요청 성공:{}}", kakaoPayDTO);
+            if (kakaoPayDTO != null) {
+                kakaoPayDTO.setDesignerScheduleId(String.valueOf(tempScheduleId));
+            }
             return kakaoPayDTO;
         } catch (RestClientException | URISyntaxException e) {
             log.error("카카오페이 요청 실패", e);

--- a/src/main/java/com/haertz/be/payment/service/KakaoPayService.java
+++ b/src/main/java/com/haertz/be/payment/service/KakaoPayService.java
@@ -54,7 +54,7 @@ public class KakaoPayService {
 
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("cid", cid);
-        parameters.put("partner_order_id", requestDTO.getPartner_order_id());
+        parameters.put("partner_order_id", requestDTO.getDesignerScheduleId());
         parameters.put("partner_user_id",currentUserId);
         parameters.put("item_name", requestDTO.getItem_name());
         parameters.put("quantity", requestDTO.getQuantity());
@@ -83,7 +83,7 @@ public class KakaoPayService {
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("cid", cid);
         parameters.put("tid", requestDTO.getTid());
-        parameters.put("partner_order_id", requestDTO.getPartner_order_id());
+        parameters.put("partner_order_id", requestDTO.getDesignerScheduleId());
         parameters.put("partner_user_id",currentUserId);
         parameters.put("pg_token", requestDTO.getPg_token());
 
@@ -103,7 +103,7 @@ public class KakaoPayService {
             paymentSaveDto.setTotalAmount(totalAmount);
             paymentSaveDto.setPaymentStatus(PaymentStatus.COMPLETED);
             paymentSaveDto.setPaymentTransaction(requestDTO.getTid());
-            paymentSaveDto.setPartnerOrderId(requestDTO.getPartner_order_id());
+            paymentSaveDto.setPartnerOrderId(requestDTO.getDesignerScheduleId());
             //2.결제내역 저장
             Payment savedpayment=paymentSaveService.savePayment(paymentSaveDto);
 

--- a/src/main/java/com/haertz/be/payment/service/KakaoPayService.java
+++ b/src/main/java/com/haertz/be/payment/service/KakaoPayService.java
@@ -1,6 +1,7 @@
 package com.haertz.be.payment.service;
 
 import com.haertz.be.common.exception.base.BaseException;
+import com.haertz.be.common.utils.AuthenticatedUserUtils;
 import com.haertz.be.payment.dto.*;
 import com.haertz.be.payment.entity.Payment;
 import com.haertz.be.payment.entity.PaymentMethod;
@@ -42,8 +43,11 @@ public class KakaoPayService {
     private final RestTemplate restTemplate= new RestTemplate();
     private final PaymentSaveService paymentSaveService;
     private final temp temp;
+    private final AuthenticatedUserUtils userUtils;
 
     public KakaoPayDTO kakaoPayReady(KakaoPayRequestDTO requestDTO) {
+        Long currentUserId = userUtils.getCurrentUserId();
+
         HttpHeaders headers = new HttpHeaders();
         headers.add("Authorization", "SECRET_KEY " + kakaoAdminKey);
         headers.add("Content-type", "application/json");
@@ -51,7 +55,7 @@ public class KakaoPayService {
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("cid", cid);
         parameters.put("partner_order_id", requestDTO.getPartner_order_id());
-        parameters.put("partner_user_id", requestDTO.getPartner_user_id());
+        parameters.put("partner_user_id",currentUserId);
         parameters.put("item_name", requestDTO.getItem_name());
         parameters.put("quantity", requestDTO.getQuantity());
         parameters.put("total_amount", requestDTO.getTotal_amount());
@@ -71,6 +75,7 @@ public class KakaoPayService {
         }
     }
     public KakaoPayApproveDto kakaoPayApprove(KakaoPayApproveRequestDto requestDTO) {
+        Long currentUserId = userUtils.getCurrentUserId();
         HttpHeaders headers = new HttpHeaders();
         headers.add("Authorization", "SECRET_KEY " + kakaoAdminKey);
         headers.add("Content-type", "application/json");
@@ -79,7 +84,7 @@ public class KakaoPayService {
         parameters.put("cid", cid);
         parameters.put("tid", requestDTO.getTid());
         parameters.put("partner_order_id", requestDTO.getPartner_order_id());
-        parameters.put("partner_user_id", requestDTO.getPartner_user_id());
+        parameters.put("partner_user_id",currentUserId);
         parameters.put("pg_token", requestDTO.getPg_token());
 
         HttpEntity<Map<String, Object>> body = new HttpEntity<>(parameters, headers);
@@ -93,7 +98,7 @@ public class KakaoPayService {
             //1. 결제 내역 저장위한 dto 설정
             PaymentSaveDto paymentSaveDto = new PaymentSaveDto();
             paymentSaveDto.setPaymentMethod(PaymentMethod.KAKAO_PAY);
-            paymentSaveDto.setUserId(Long.valueOf(requestDTO.getPartner_user_id()));
+            paymentSaveDto.setUserId(currentUserId);
             paymentSaveDto.setPaymentDate(new Date());
             paymentSaveDto.setTotalAmount(totalAmount);
             paymentSaveDto.setPaymentStatus(PaymentStatus.COMPLETED);
@@ -122,6 +127,7 @@ public class KakaoPayService {
         }
     }
     public KakaoPayCancelDto kakaoPayCancel(KakaoPayCancelRequestDto requestDTO) {
+        Long currentUserId = userUtils.getCurrentUserId();
         HttpHeaders headers = new HttpHeaders();
         headers.add("Authorization", "SECRET_KEY " + kakaoAdminKey);
         headers.add("Content-type", "application/json");
@@ -130,7 +136,7 @@ public class KakaoPayService {
         parameters.put("cid", cid);
         parameters.put("tid", requestDTO.getTid());
         parameters.put("partner_order_id", requestDTO.getPartnerOrderId());
-        parameters.put("partner_user_id", requestDTO.getPartnerUserId());
+        parameters.put("partner_user_id", currentUserId);
         parameters.put("cancel_amount", requestDTO.getCancelAmount());
         parameters.put("cancel_tax_free_amount", requestDTO.getCancelTaxFreeAmount());
 

--- a/src/main/java/com/haertz/be/payment/service/KakaoPayService.java
+++ b/src/main/java/com/haertz/be/payment/service/KakaoPayService.java
@@ -158,13 +158,15 @@ public class KakaoPayService {
             payment.setPaymentStatus(PaymentStatus.REFUNDED);
             temp.save(payment);
 
+            // 디자이너 스케줄 테이블 삭제 함수 호출
+            Long designerScheduleId= Long.valueOf(payment.getPartnerOrderId());
+            designerScheduleDomainService.deleteScheduleAfterFailedPayment(designerScheduleId);
+
             KakaoPayCancelDto kakaoPayCancelDto = new KakaoPayCancelDto();
             kakaoPayCancelDto.setCid(cancelResponse.getCid());
             kakaoPayCancelDto.setTid(cancelResponse.getTid());
             kakaoPayCancelDto.setPaymentstatus(payment.getPaymentStatus());
 
-            // 추후 디자이너 예약 확정 엔티티에서 해당 partner_order_id를 통해 예약 데이터를 삭제로직 구현
-            // designerBookingRepository.deleteByPartnerOrderId(requestDTO.getPartnerOrderId());
             return kakaoPayCancelDto;
         } catch (RestClientException | URISyntaxException e) {
             log.error("결제 취소 실패", e);

--- a/src/main/java/com/haertz/be/payment/service/KakaoPayService.java
+++ b/src/main/java/com/haertz/be/payment/service/KakaoPayService.java
@@ -1,5 +1,6 @@
 package com.haertz.be.payment.service;
 
+import com.haertz.be.booking.service.DesignerScheduleDomainService;
 import com.haertz.be.common.exception.base.BaseException;
 import com.haertz.be.common.utils.AuthenticatedUserUtils;
 import com.haertz.be.payment.dto.*;
@@ -44,6 +45,7 @@ public class KakaoPayService {
     private final PaymentSaveService paymentSaveService;
     private final temp temp;
     private final AuthenticatedUserUtils userUtils;
+    private final DesignerScheduleDomainService designerScheduleDomainService;
 
     public KakaoPayDTO kakaoPayReady(KakaoPayRequestDTO requestDTO) {
         Long currentUserId = userUtils.getCurrentUserId();
@@ -106,6 +108,9 @@ public class KakaoPayService {
             paymentSaveDto.setPartnerOrderId(requestDTO.getDesignerScheduleId());
             //2.결제내역 저장
             Payment savedpayment=paymentSaveService.savePayment(paymentSaveDto);
+
+            // 디자이너 스케줄의 상태를 변경 메서드 호출
+            designerScheduleDomainService.confirmScheduleAfterPayment(Long.valueOf(requestDTO.getDesignerScheduleId()), PaymentStatus.COMPLETED);
 
             /*구글 미팅링크 생성 관련 코드들
             GoogleMeetRequestDto googleMeetRequestDto = new GoogleMeetRequestDto();


### PR DESCRIPTION
# PR

## PR 요약
1. 유저와 결제를 연결
2. 카카오페이 결제 완료 후 디자이너스케줄의 상태를 변경하는 로직 구현
3. 계좌이체 취소, 카카오페이 환불 시 디자이너 스케줄 테이블 삭제 로직 구현
4. 카카오페이 결제 시도하면 디자이너스케줄 테이블 생성로직 구현 (응답으로 designerScheduleId도 반환)

## 변경된 점
2,3,4번은 미리 구현해두신 DesignerScheduleDomainService의 함수를 사용하였습니다. 

## 이슈 번호
issue number #39 