### PR TITLE
feat: 예약 취소 API 구현

### DIFF
--- a/src/main/java/com/haertz/be/booking/adaptor/BookingAdaptor.java
+++ b/src/main/java/com/haertz/be/booking/adaptor/BookingAdaptor.java
@@ -1,23 +1,27 @@
 package com.haertz.be.booking.adaptor;
 
 import com.haertz.be.booking.entity.Booking;
+import com.haertz.be.booking.exception.BookingErrorCode;
 import com.haertz.be.booking.repository.BookingRepository;
 import com.haertz.be.common.annotation.Adaptor;
+import com.haertz.be.common.exception.base.BaseException;
 import lombok.RequiredArgsConstructor;
-
-import java.time.LocalDate;
-import java.time.LocalTime;
 
 @Adaptor
 @RequiredArgsConstructor
 public class BookingAdaptor {
     private final BookingRepository bookingRepository;
 
-    public Booking save(Booking booking){
+    public Booking save(Booking booking) {
         return bookingRepository.save(booking);
     }
 
-    public Boolean existsByDesignerScheduleId(Long designerScheduleId){
+    public Boolean existsByDesignerScheduleId(Long designerScheduleId) {
         return bookingRepository.existsByDesignerScheduleId(designerScheduleId);
+    }
+
+    public Booking findById(Long bookingId) {
+        return bookingRepository.findById(bookingId)
+                .orElseThrow(() -> new BaseException(BookingErrorCode.BOOKING_NOT_FOUND));
     }
 }

--- a/src/main/java/com/haertz/be/booking/controller/BookingController.java
+++ b/src/main/java/com/haertz/be/booking/controller/BookingController.java
@@ -37,7 +37,7 @@ public class BookingController {
 
     @Operation(summary = "헤어 컨설팅 일정 예약을 요청합니다.")
     @PostMapping
-    public SuccessResponse<BookingResponse> book(@RequestBody @Valid BookingInfoRequest bookingInfoRequest) {
+    public SuccessResponse<Object> book(@RequestBody @Valid BookingInfoRequest bookingInfoRequest) {
         BookingResponse bookingResponse = bookUseCase.execute(bookingInfoRequest);
         return SuccessResponse.of(bookingResponse);
     }

--- a/src/main/java/com/haertz/be/booking/controller/BookingController.java
+++ b/src/main/java/com/haertz/be/booking/controller/BookingController.java
@@ -6,6 +6,7 @@ import com.haertz.be.booking.entity.Booking;
 import com.haertz.be.booking.service.BookingDomainService;
 import com.haertz.be.booking.service.BookingService;
 import com.haertz.be.booking.usecase.BookUseCase;
+import com.haertz.be.booking.usecase.CancelBookingWithRefundUseCase;
 import com.haertz.be.booking.usecase.GetAvailableDatesUseCase;
 import com.haertz.be.booking.usecase.GetAvailableTimesUseCase;
 import com.haertz.be.common.response.SuccessResponse;
@@ -30,6 +31,7 @@ public class BookingController {
     private final BookUseCase bookUseCase;
     private final GetAvailableDatesUseCase getAvailableDatesUseCase;
     private final GetAvailableTimesUseCase getAvailableTimesUseCase;
+    private final CancelBookingWithRefundUseCase cancelBookingWithRefundUseCase;
 
     private final BookingService bookingService;
 
@@ -54,11 +56,17 @@ public class BookingController {
         return SuccessResponse.of(Collections.singletonMap("예약 가능 시간 리스트: ", availableTimes));
     }
 
+    @Operation(summary = "선택한 예약 일정을 취소합니다.")
+    @DeleteMapping("/{bookingId}")
+    public SuccessResponse<Void> cancelBookingWithRefund(@PathVariable Long bookingId){
+        cancelBookingWithRefundUseCase.execute(bookingId);
+        return SuccessResponse.empty();
+    }
+
     @Operation(summary = "사용자의 다가오는 예약 내역을 조회합니다.")
     @GetMapping("/current")
     public SuccessResponse<Object> getBookings(){
         List<Booking> bookingList = bookingService.getCurrentBookings();
-
         return SuccessResponse.of(bookingList);
     }
 
@@ -66,7 +74,6 @@ public class BookingController {
     @GetMapping("/past")
     public SuccessResponse<Object> getPastBookings(){
         List<Booking> bookingList = bookingService.getPastBookings();
-
         return SuccessResponse.of(bookingList);
     }
 }

--- a/src/main/java/com/haertz/be/booking/converter/BookingConverter.java
+++ b/src/main/java/com/haertz/be/booking/converter/BookingConverter.java
@@ -21,6 +21,7 @@ public class BookingConverter {
                 .bookingStatus(schedule.getPaymentStatus() == PaymentStatus.COMPLETED ? BookingStatus.CONFIRMED : BookingStatus.PENDING)
                 .meetingType(bookingInfo.meetingType())
                 .requestDetails(bookingInfo.requestDetails())
+                .designerScheduleId(schedule.getDesignerScheduleId())
                 .userId(userId)
                 .designer(designer)
                 .build();

--- a/src/main/java/com/haertz/be/booking/converter/BookingConverter.java
+++ b/src/main/java/com/haertz/be/booking/converter/BookingConverter.java
@@ -44,6 +44,7 @@ public class BookingConverter {
                 .bookingTime(preBookingRequest.bookingTime())
                 .designerId(preBookingRequest.designerId())
                 .paymentStatus(paymentStatus)
+                .isTemporary(true)
                 .userId(userId)
                 .build();
     }

--- a/src/main/java/com/haertz/be/booking/dto/response/BookingResponse.java
+++ b/src/main/java/com/haertz/be/booking/dto/response/BookingResponse.java
@@ -7,12 +7,14 @@ import com.haertz.be.booking.entity.MeetingType;
 import com.haertz.be.payment.entity.PaymentStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Data;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
 
 @AllArgsConstructor
 @Builder
+@Data
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class BookingResponse {
 

--- a/src/main/java/com/haertz/be/booking/entity/Booking.java
+++ b/src/main/java/com/haertz/be/booking/entity/Booking.java
@@ -1,6 +1,5 @@
 package com.haertz.be.booking.entity;
 
-import com.haertz.be.auth.entity.User;
 import com.haertz.be.common.entity.BaseTimeEntity;
 import com.haertz.be.designer.entity.Designer;
 import com.haertz.be.payment.entity.PaymentStatus;
@@ -52,8 +51,17 @@ public class Booking extends BaseTimeEntity {
     @JoinColumn(name = "designer_id", nullable = false)
     private Designer designer;
 
-    @Column(nullable = true)
+    @Column(nullable = true, unique = true)
     private Long designerScheduleId;
 
+    public void refundAndCancelBooking(){
+        this.paymentStatus = PaymentStatus.REFUNDED;
+        this.bookingStatus = BookingStatus.CANCELED;
+        this.designerScheduleId = null;
+    }
+    public void confirmBankTransferPayment(){
+        this.paymentStatus = PaymentStatus.COMPLETED;
+        this.bookingStatus = BookingStatus.CONFIRMED;
+    }
 
 }

--- a/src/main/java/com/haertz/be/booking/exception/BookingErrorCode.java
+++ b/src/main/java/com/haertz/be/booking/exception/BookingErrorCode.java
@@ -12,8 +12,10 @@ public enum BookingErrorCode implements BaseErrorCode {
     INVALID_TIME_FORMAT(400, "BOOKING_400_3", "예약 시간은 30분 단위여야 합니다."),
     OUT_OF_AVAILABLE_TIME_RANGE(400, "BOOKING_400_4", "예약 가능한 시간 범위를 벗어났습니다."),
 
-    DESIGNER_SCHEDULE_NOT_FOUND(404, "SCHEDULE_404","예약된 일정 정보를 찾을 수 없습니다."),
-    BOOKING_ALREADY_REGISTERED(409, "BOOKING_409", "이미 다른 사람이 예약한 시간대입니다.");
+    BOOKING_NOT_FOUND(404, "BOOKING_404","예약 정보를 찾을 수 없습니다."),
+    BOOKING_ALREADY_REGISTERED(409, "BOOKING_409_1", "이미 다른 사람이 예약한 시간대입니다."),
+    BOOKING_ALREADY_CANCELED(409, "BOOKING_409_2", "이미 취소된 예약입니다."),
+    DESIGNER_SCHEDULE_NOT_FOUND(404, "SCHEDULE_404","예약된 일정 정보를 찾을 수 없습니다.");
 
     private final int httpStatus;
     private final String code;

--- a/src/main/java/com/haertz/be/booking/service/BookingDomainService.java
+++ b/src/main/java/com/haertz/be/booking/service/BookingDomainService.java
@@ -4,7 +4,10 @@ import com.haertz.be.booking.adaptor.BookingAdaptor;
 import com.haertz.be.booking.converter.BookingConverter;
 import com.haertz.be.booking.dto.request.BookingInfoRequest;
 import com.haertz.be.booking.entity.Booking;
+import com.haertz.be.booking.entity.BookingStatus;
 import com.haertz.be.booking.entity.DesignerSchedule;
+import com.haertz.be.booking.exception.BookingErrorCode;
+import com.haertz.be.common.exception.base.BaseException;
 import com.haertz.be.designer.entity.Designer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,6 +21,13 @@ public class BookingDomainService {
     public Booking book(BookingInfoRequest bookingInfo, Designer designer, Long userId, DesignerSchedule schedule){
         Booking book = BookingConverter.toBooking(bookingInfo, designer, userId, schedule);
         return bookingAdaptor.save(book);
+    }
+    @Transactional
+    public void cancelBooking(Booking booking){
+        if (!(booking.getBookingStatus().equals(BookingStatus.CANCELED))){
+            booking.refundAndCancelBooking();
+            bookingAdaptor.save(booking);
+        } else throw new BaseException(BookingErrorCode.BOOKING_ALREADY_CANCELED);
     }
 
 }

--- a/src/main/java/com/haertz/be/booking/usecase/CancelBookingWithRefundUseCase.java
+++ b/src/main/java/com/haertz/be/booking/usecase/CancelBookingWithRefundUseCase.java
@@ -1,0 +1,34 @@
+package com.haertz.be.booking.usecase;
+
+import com.haertz.be.booking.adaptor.BookingAdaptor;
+import com.haertz.be.booking.entity.Booking;
+import com.haertz.be.booking.service.BookingDomainService;
+import com.haertz.be.booking.service.DesignerScheduleDomainService;
+import com.haertz.be.common.annotation.UseCase;
+import com.haertz.be.common.exception.GlobalErrorCode;
+import com.haertz.be.common.exception.base.BaseException;
+import com.haertz.be.common.utils.AuthenticatedUserUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+public class CancelBookingWithRefundUseCase {
+
+    private final BookingDomainService bookingDomainService;
+    private final DesignerScheduleDomainService designerScheduleDomainService;
+    private final BookingAdaptor bookingAdaptor;
+    private final AuthenticatedUserUtils userUtils;
+
+    @Transactional
+    public void execute(Long bookingId){
+        Booking booking = bookingAdaptor.findById(bookingId);
+
+        if(!booking.getUserId().equals(userUtils.getCurrentUserId())){
+            throw new BaseException(GlobalErrorCode.UNAUTHORIZED_REQUEST_ERROR);
+        }
+
+        designerScheduleDomainService.deleteScheduleAfterFailedPayment(booking.getDesignerScheduleId());
+        bookingDomainService.cancelBooking(booking);
+    }
+}

--- a/src/main/java/com/haertz/be/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/haertz/be/common/config/security/SecurityConfig.java
@@ -42,7 +42,7 @@ public class SecurityConfig {
                         .requestMatchers(swaggerUrlPatterns).permitAll()
                         .requestMatchers("/api/auth/login").permitAll()
                         .requestMatchers("/api/auth/signup").permitAll()
-                        .requestMatchers("/api/auth/idToken").permitAll()
+                        .requestMatchers("/api/auth/idtoken").permitAll()
                         .requestMatchers("/api/auth/refresh").permitAll()
                         .requestMatchers("/login/oauth2/**").permitAll()  // OAuth 로그인 경로 허용
                         .anyRequest().authenticated()
@@ -75,7 +75,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("http://localhost:3000", "http://localhost:8080", "https://haertz.kr","https://www.haertz.kr", "https://haertz.kr/", "https://backend.haertz.kr","http://localhost:5173"));
+        configuration.setAllowedOrigins(List.of("http://localhost:3000", "http://localhost:8081", "https://haertz.kr","https://www.haertz.kr", "https://haertz.kr/", "https://backend.haertz.kr","http://localhost:5173"));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowCredentials(true);
         configuration.setAllowedHeaders(List.of("Authorization", "Content-Type"));

--- a/src/main/java/com/haertz/be/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/haertz/be/common/config/security/SecurityConfig.java
@@ -41,7 +41,9 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(swaggerUrlPatterns).permitAll()
                         .requestMatchers("/api/auth/login").permitAll()
-                        .requestMatchers("/api/**").permitAll() // 임시로 추가 TODO 삭제 예정
+                        .requestMatchers("/api/auth/signup").permitAll()
+                        .requestMatchers("/api/auth/idToken").permitAll()
+                        .requestMatchers("/api/auth/refresh").permitAll()
                         .requestMatchers("/login/oauth2/**").permitAll()  // OAuth 로그인 경로 허용
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/haertz/be/common/exception/GlobalErrorCode.java
+++ b/src/main/java/com/haertz/be/common/exception/GlobalErrorCode.java
@@ -13,6 +13,7 @@ public enum GlobalErrorCode implements BaseErrorCode {
 
     BAD_REQUEST_ERROR(400, "GLOBAL_400_1", "잘못된 요청입니다."),
 
+
     INVALID_HTTP_MESSAGE_BODY(400, "GLOBAL_400_2", "HTTP 요청 바디의 형식이 잘못되었습니다."),
     INVALID_REQUEST_CONTENT(400, "GLOBAL_400_3", "잘못된 데이터를 포함한 요청입니다."),
     ACCESS_DENIED_REQUEST(403, "GLOBAL_403", "해당 요청에 접근 권한이 없습니다."),
@@ -28,6 +29,8 @@ public enum GlobalErrorCode implements BaseErrorCode {
     INCORRECT_ISSUER_TOKEN(401, "TOKEN_401_4", "토큰 발급처가 일치하지 않습니다."),
     EXPIRED_TOKEN(401, "TOKEN_401_5", "토큰이 만료되었습니다."),
     NOT_MATCHED_TOKEN_TYPE(401, "TOKEN_401_6", "토큰의 타입이 일치하지 않아 디코딩할 수 없습니다."),
+
+    UNAUTHORIZED_REQUEST_ERROR(403, "GLOBAL_403", "허용되지 않은 요청입니다."),
 
     TOKEN_HEADER_NOT_FOUND(404,"TOKEN_404_1","토큰에 KID가 존재하지 않습니다."),
 

--- a/src/main/java/com/haertz/be/designer/entity/Designer.java
+++ b/src/main/java/com/haertz/be/designer/entity/Designer.java
@@ -28,9 +28,11 @@ public class Designer extends BaseTimeEntity {
 
     @Column(name = "designer_shop")
 
+
     private String designerShop; //매장주소
 
     @Column(name = "designer_district")
+    @Enumerated(EnumType.STRING)
     private District designerDistrict;
 
     @ElementCollection(targetClass = Specialty.class)
@@ -40,14 +42,14 @@ public class Designer extends BaseTimeEntity {
     private List<Specialty> designerSpecialty;
 
     @Column(name = "designer_contact_cost")
-    private Integer designerContactCost; //대면 가격
+    private Integer designerContactCost; // 대면 가격
 
     @Column(name = "designer_untact_cost")
-    private Integer designerUntactCost; //비대면 가격
+    private Integer designerUntactCost; // 비대면 가격
 
 
     @Column(name = "designer_description")
-    private String designerDescription; //디자이너 한줄소개
+    private String designerDescription; // 디자이너 한줄소개
 
 
 


### PR DESCRIPTION
# PR

## PR 요약
- 예약 취소 API 구현했습니다. 사용자가 예약을 취소하면, DesignerSchedule이 삭제되고, Booking의 상태값이 변경됩니다.

## 변경된 점
- Designer의 enum 필드에@Enumerated(EnumType.STRING) 추가로 에러 수정 (@bibisam06 확인 부탁드립니다.)
- SecurityConfig 허용 url 변경 (8080 -> 8081)
- 대략 테스트 단계가 마무리 되는 것 같아 인증 관련 API만 허용하도록 보안설정 수정했습니다.

## 이슈 번호
resolved #29 