### PR TITLE
refactor: 디자이너 미팅 방식에 맞춘 예약 검증 기능 추가

### DIFF
--- a/src/main/java/com/haertz/be/booking/entity/MeetingType.java
+++ b/src/main/java/com/haertz/be/booking/entity/MeetingType.java
@@ -6,8 +6,8 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public enum MeetingType {
-    ONLINE("ONLINE"),
-    OFFLINE("OFFLINE");
+    REMOTE("REMOTE"),
+    FACE_TO_FACE("FACE_TO_FACE");
 
     public final String value;
 }

--- a/src/main/java/com/haertz/be/booking/exception/BookingErrorCode.java
+++ b/src/main/java/com/haertz/be/booking/exception/BookingErrorCode.java
@@ -12,7 +12,9 @@ public enum BookingErrorCode implements BaseErrorCode {
     INVALID_TIME_FORMAT(400, "BOOKING_400_3", "예약 시간은 30분 단위여야 합니다."),
     OUT_OF_AVAILABLE_TIME_RANGE(400, "BOOKING_400_4", "예약 가능한 시간 범위를 벗어났습니다."),
 
+
     BOOKING_NOT_FOUND(404, "BOOKING_404","예약 정보를 찾을 수 없습니다."),
+
     BOOKING_ALREADY_REGISTERED(409, "BOOKING_409_1", "이미 다른 사람이 예약한 시간대입니다."),
     BOOKING_ALREADY_CANCELED(409, "BOOKING_409_2", "이미 취소된 예약입니다."),
     DESIGNER_SCHEDULE_NOT_FOUND(404, "SCHEDULE_404","예약된 일정 정보를 찾을 수 없습니다.");

--- a/src/main/java/com/haertz/be/booking/service/BookingDomainService.java
+++ b/src/main/java/com/haertz/be/booking/service/BookingDomainService.java
@@ -6,9 +6,12 @@ import com.haertz.be.booking.dto.request.BookingInfoRequest;
 import com.haertz.be.booking.entity.Booking;
 import com.haertz.be.booking.entity.BookingStatus;
 import com.haertz.be.booking.entity.DesignerSchedule;
+import com.haertz.be.booking.entity.MeetingType;
 import com.haertz.be.booking.exception.BookingErrorCode;
 import com.haertz.be.common.exception.base.BaseException;
 import com.haertz.be.designer.entity.Designer;
+import com.haertz.be.designer.entity.MeetingMode;
+import com.haertz.be.designer.exception.DesignerErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,9 +22,25 @@ public class BookingDomainService {
     private final BookingAdaptor bookingAdaptor;
     @Transactional
     public Booking book(BookingInfoRequest bookingInfo, Designer designer, Long userId, DesignerSchedule schedule){
+        validateMeetingType(bookingInfo.meetingType(), designer.getMeetingMode());
         Booking book = BookingConverter.toBooking(bookingInfo, designer, userId, schedule);
         return bookingAdaptor.save(book);
     }
+
+    private void validateMeetingType(MeetingType requestMeetingType, MeetingMode designerMeetingMode) {
+        if (designerMeetingMode == MeetingMode.BOTH) {
+            return;
+        }
+
+        MeetingType meetingType = designerMeetingMode.toMeetingType()
+                .orElseThrow(() -> new BaseException(DesignerErrorCode.INVALID_MEETING_MODE));
+
+        if (meetingType != requestMeetingType) {
+            throw new BaseException(DesignerErrorCode.DESIGNER_UNSUPPORTED_MEETING);
+        }
+    }
+
+
     @Transactional
     public void cancelBooking(Booking booking){
         if (!(booking.getBookingStatus().equals(BookingStatus.CANCELED))){

--- a/src/main/java/com/haertz/be/booking/usecase/BookUseCase.java
+++ b/src/main/java/com/haertz/be/booking/usecase/BookUseCase.java
@@ -7,6 +7,7 @@ import com.haertz.be.booking.dto.request.BookingInfoRequest;
 import com.haertz.be.booking.dto.response.BookingResponse;
 import com.haertz.be.booking.entity.Booking;
 import com.haertz.be.booking.entity.DesignerSchedule;
+import com.haertz.be.booking.entity.MeetingType;
 import com.haertz.be.booking.exception.BookingErrorCode;
 import com.haertz.be.booking.service.BookingDomainService;
 import com.haertz.be.common.annotation.UseCase;
@@ -14,6 +15,8 @@ import com.haertz.be.common.exception.base.BaseException;
 import com.haertz.be.common.utils.AuthenticatedUserUtils;
 import com.haertz.be.designer.adaptor.DesignerAdaptor;
 import com.haertz.be.designer.entity.Designer;
+import com.haertz.be.designer.entity.MeetingMode;
+import com.haertz.be.designer.exception.DesignerErrorCode;
 import lombok.RequiredArgsConstructor;
 
 
@@ -29,17 +32,21 @@ public class BookUseCase {
     public BookingResponse execute(BookingInfoRequest bookingInfo) {
         Long currentUserId = userUtils.getCurrentUserId();
 
+         // DesignerSchedule에 등록 여부 검증
         if (!designerScheduleAdaptor.hasUserBookedSchedule(currentUserId, bookingInfo.designerScheduleId())) {
             throw new BaseException(BookingErrorCode.DESIGNER_SCHEDULE_NOT_FOUND);
         }
 
+        // 결제 상태 검증
         DesignerSchedule designerSchedule = designerScheduleAdaptor.isPaymentStatusValid(bookingInfo.designerScheduleId());
 
+        // 이미 예약된 스케쥴인지 검증
         if (bookingAdaptor.existsByDesignerScheduleId(bookingInfo.designerScheduleId())) {
             throw new BaseException(BookingErrorCode.BOOKING_ALREADY_REGISTERED);
         }
 
         Designer designer = designerAdaptor.findByDesignerId(designerSchedule.getDesignerId());
+
         Booking booking = bookingDomainService.book(bookingInfo, designer, currentUserId, designerSchedule);
 
         return BookingConverter.toBookingResponse(booking, designer.getDesignerName());

--- a/src/main/java/com/haertz/be/designer/entity/Designer.java
+++ b/src/main/java/com/haertz/be/designer/entity/Designer.java
@@ -6,8 +6,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.List;
-
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity

--- a/src/main/java/com/haertz/be/designer/entity/MeetingMode.java
+++ b/src/main/java/com/haertz/be/designer/entity/MeetingMode.java
@@ -1,7 +1,25 @@
 package com.haertz.be.designer.entity;
 
+import com.haertz.be.booking.entity.MeetingType;
+import com.haertz.be.common.exception.base.BaseException;
+import com.haertz.be.designer.exception.DesignerErrorCode;
+
+import java.util.Optional;
+
 public enum MeetingMode {
     REMOTE,        // 비대면만 가능한 경우
     FACE_TO_FACE,  // 대면만 가능한 경우
-    BOTH           // 대면, 비대면 모두 가능한 경우
+    BOTH;          // 대면, 비대면 모두 가능한 경우
+
+    public Optional<MeetingType> toMeetingType() {
+        if (this == BOTH) {
+            return Optional.empty();
+        }
+        return switch (this) {
+            case REMOTE -> Optional.of(MeetingType.REMOTE);
+            case FACE_TO_FACE -> Optional.of(MeetingType.FACE_TO_FACE);
+            default -> throw new BaseException(DesignerErrorCode.INVALID_MEETING_MODE);
+        };
+    }
 }
+

--- a/src/main/java/com/haertz/be/designer/exception/DesignerErrorCode.java
+++ b/src/main/java/com/haertz/be/designer/exception/DesignerErrorCode.java
@@ -7,7 +7,9 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum DesignerErrorCode implements BaseErrorCode{
-    DESIGNER_NOT_FOUND(404, "DESIGNER_404","디자이너를 찾을 수 없습니다.");
+    DESIGNER_UNSUPPORTED_MEETING(405, "DESIGNER_400", "해당 디자이너에 해당 미팅 방식을 지원하지 않습니다."),
+    DESIGNER_NOT_FOUND(404, "DESIGNER_404","디자이너를 찾을 수 없습니다."),
+    INVALID_MEETING_MODE(400, "DESIGNER_400_INVALID", "잘못된 미팅 방식입니다.");;
 
     private final int httpStatus;
     private final String code;


### PR DESCRIPTION
# PR

## PR 요약
- 디자이너 미팅 방식에 맞춘 예약 검증 기능을 구현했습니다.
- 프론트 측에서 이미 1차 검증을 수행하지만, 백엔드에서 추가로 검증합니다.

## 변경된 점
- MeetingMode.toMeetingType() 메서드 추가하여 디자이너가 가능한 값과 사용자가 입력한 값의 일치 여부를 확인합니다.
- BOTH나 일치할 경우엔 성공이며, 다를 경우에 에러를 반환합니다.

## 이슈 번호
resolved #51 