### PR TITLE
feat: 결제 취소 시 디자이너스케줄 테이블 삭제

### DIFF
--- a/src/main/java/com/haertz/be/booking/entity/DesignerSchedule.java
+++ b/src/main/java/com/haertz/be/booking/entity/DesignerSchedule.java
@@ -17,6 +17,7 @@ import java.time.LocalTime;
 @Entity
 @Getter
 @Builder
+@Setter
 @AllArgsConstructor
 @Table(name = "designer_schedule", uniqueConstraints = @UniqueConstraint(columnNames = {"designer_id", "booking_date", "booking_time"}))
 public class DesignerSchedule extends BaseTimeEntity {

--- a/src/main/java/com/haertz/be/booking/entity/DesignerSchedule.java
+++ b/src/main/java/com/haertz/be/booking/entity/DesignerSchedule.java
@@ -17,7 +17,6 @@ import java.time.LocalTime;
 @Entity
 @Getter
 @Builder
-@Setter
 @AllArgsConstructor
 @Table(name = "designer_schedule", uniqueConstraints = @UniqueConstraint(columnNames = {"designer_id", "booking_date", "booking_time"}))
 public class DesignerSchedule extends BaseTimeEntity {

--- a/src/main/java/com/haertz/be/payment/controller/KakaopayController.java
+++ b/src/main/java/com/haertz/be/payment/controller/KakaopayController.java
@@ -1,5 +1,6 @@
 package com.haertz.be.payment.controller;
 
+import com.haertz.be.common.response.SuccessResponse;
 import com.haertz.be.payment.service.KakaoPayService;
 import com.haertz.be.payment.dto.*;
 import io.swagger.v3.oas.annotations.Operation;
@@ -42,7 +43,7 @@ public class KakaopayController {
     }
     /*
     @Operation(summary="카카오페이 결제 취소 요청을 보냅니다. 결제가 완료된(승인된) 건에 대해 환불 처리를 하기 위해 Kakao Pay의 결제 취소 API를 호출하는 로직입니다.")
-    @PostMapping("/api/kakaPay/cancel")
+    @PostMapping("/api/kakaPay/refund")
     public ResponseEntity<KakaoPayCancelDto> kakaoPaycancel(@RequestBody KakaoPayCancelRequestDto requestDTO){
         KakaoPayCancelDto approveResponse=kakaoPayService.kakaoPayCancel(requestDTO);
         if (approveResponse != null) {
@@ -53,4 +54,10 @@ public class KakaopayController {
     }
 
      */
+    @Operation(summary="카카오페이 결제중(결제 완료하기 전임) 취소를 선택할경우, 결제 완료 후 취소는 예약삭제 api이용.")
+    @PostMapping("/api/kakaoPay/cancel")
+    public SuccessResponse payingcancel(@RequestBody PayingCancelRequestDto requestDTO){
+        kakaoPayService.payingcancel(requestDTO);
+        return SuccessResponse.empty();
+    }
 }

--- a/src/main/java/com/haertz/be/payment/dto/PayingCancelRequestDto.java
+++ b/src/main/java/com/haertz/be/payment/dto/PayingCancelRequestDto.java
@@ -1,0 +1,14 @@
+package com.haertz.be.payment.dto;
+
+import lombok.*;
+
+//카카오페이 결제도중 취소하는 요청을 보내기 위한 dto
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class PayingCancelRequestDto {
+    //private String tid;
+    private Long designerScheduleId;
+}


### PR DESCRIPTION
# PR

## PR 요약
카카오페이 결제 중(결제 완료 상태 아님) 결제 취소시 이미 생성되어있던 디자이너스케줄 테이블을 삭제처리합니다.
결제처리 완료후 취소하는 로직은 미리 구현해두었던 예약취소 api를 사용하면 됩니다. 

## 변경된 점
/api/kakaoPay/cancel 를 카카오페이 결제 도중 결제취소하는 api로 변경하였습니다. 

## 이슈 번호
issue number #46 